### PR TITLE
Add generics TokenType

### DIFF
--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -7,9 +7,7 @@ export interface IUsePublishResponse {
   publish: () => void
 }
 
-export interface IUsePublishParams<
-  TokenType extends string | symbol = string | symbol,
-> {
+export interface IUsePublishParams<TokenType extends string | symbol> {
   token: TokenType
   message: string
   isAutomatic?: boolean
@@ -18,9 +16,7 @@ export interface IUsePublishParams<
   debounceMs?: number | string
 }
 
-export const usePublish = <
-  TokenType extends string | symbol = string | symbol,
->({
+export const usePublish = <TokenType extends string | symbol>({
   token,
   message,
   isAutomatic = false,

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -7,8 +7,10 @@ export interface IUsePublishResponse {
   publish: () => void
 }
 
-export interface IUsePublishParams {
-  token: string
+export interface IUsePublishParams<
+  TokenType extends string | symbol = string | symbol,
+> {
+  token: TokenType
   message: string
   isAutomatic?: boolean
   isInitialPublish?: boolean
@@ -16,14 +18,16 @@ export interface IUsePublishParams {
   debounceMs?: number | string
 }
 
-export const usePublish = ({
+export const usePublish = <
+  TokenType extends string | symbol = string | symbol,
+>({
   token,
   message,
   isAutomatic = false,
   isInitialPublish = false,
   isImmediate = false,
   debounceMs = 300,
-}: IUsePublishParams): IUsePublishResponse => {
+}: IUsePublishParams<TokenType>): IUsePublishResponse => {
   const [lastPublish, setLastPublish] = useState(false)
 
   const publish = useCallback(() => {

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -6,17 +6,13 @@ export interface UseSubscriptionResponse {
   resubscribe: () => void
 }
 
-export interface UseSubscriptionParams<
-  TokenType extends string | symbol = string | symbol,
-> {
+export interface UseSubscriptionParams<TokenType extends string | symbol> {
   token: TokenType
   handler: (token?: TokenType, message?: string) => void
   isUnsubscribe?: boolean
 }
 
-export const useSubscribe = <
-  TokenType extends string | symbol = string | symbol,
->({
+export const useSubscribe = <TokenType extends string | symbol>({
   token,
   handler,
   isUnsubscribe = false,

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -6,17 +6,21 @@ export interface UseSubscriptionResponse {
   resubscribe: () => void
 }
 
-export interface UseSubscriptionParams {
-  token: string | symbol
-  handler: (token?: string | symbol, message?: string) => void
+export interface UseSubscriptionParams<
+  TokenType extends string | symbol = string | symbol,
+> {
+  token: TokenType
+  handler: (token?: TokenType, message?: string) => void
   isUnsubscribe?: boolean
 }
 
-export const useSubscribe = ({
+export const useSubscribe = <
+  TokenType extends string | symbol = string | symbol,
+>({
   token,
   handler,
   isUnsubscribe = false,
-}: UseSubscriptionParams): UseSubscriptionResponse => {
+}: UseSubscriptionParams<TokenType>): UseSubscriptionResponse => {
   const unsubscribe = useCallback(() => {
     PubSub.unsubscribe(handler)
   }, [handler])


### PR DESCRIPTION
Allow passing of `TokenType` to both `useSubscribe` and `usePublish` to define what values the token can be.

This is useful to use in combination with union strings to limit possible tokens. Eg:
```ts
type PossibleTokens = "event1" | "event2" | "event3";

useSubscribe<PossibleTokens>({ token: "event1", ... }); // Works
useSubscribe<PossibleTokens>({ token: "event2", ... }); // Works

useSubscribe<PossibleTokens>({ token: "randomEvent", ... }); // Error
```

