### PR TITLE
chore(quality): packaging/types/test/CI fixes from multi-lens review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pnpm install
-        pnpm --prefix ./example install
+        pnpm install --frozen-lockfile
+        pnpm --prefix ./example install --frozen-lockfile
 
     - name: Check tests
       run: pnpm test --coverage

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,8 +14,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
 
     - name: Install pnpm
       uses: pnpm/action-setup@v6
@@ -24,7 +25,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Run e2e tests
       run: pnpm test:e2e

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install
-          pnpm --prefix ./example install
+          pnpm install --frozen-lockfile
+          pnpm --prefix ./example install --frozen-lockfile
 
       - name: Build
         run: |

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 <a target="_blank" href="https://www.npmjs.com/package/use-pubsub-js">
   <img src="https://img.shields.io/npm/v/use-pubsub-js.svg" alt="Coverage Status">
 </a>
-<a target="_blank" href="https://coveralls.io/github/reactivando/use-pubsub-js?branch=master">
-  <img src="https://coveralls.io/repos/github/reactivando/use-pubsub-js/badge.svg?branch=master" alt="Coverage Status">
+<a target="_blank" href="https://coveralls.io/github/reactivando/use-pubsub-js?branch=main">
+  <img src="https://coveralls.io/repos/github/reactivando/use-pubsub-js/badge.svg?branch=main" alt="Coverage Status">
 </a>
-<a target="_blank" href="https://github.com/reactivando/use-pubsub-js/blob/master/LICENSE">
+<a target="_blank" href="https://github.com/reactivando/use-pubsub-js/blob/main/LICENSE">
   <img src="https://img.shields.io/github/license/reactivando/use-pubsub-js?style=plastic" alt="LICENSE">
 </a>
 <a target="_blank" href="https://app.codacy.com/gh/reactivando/use-pubsub-js/dashboard">
@@ -122,7 +122,7 @@ const ExampleUsePublish = () => {
 
   return (
     <div>
-      <p>{lastPublish ? Publishing success : Publication failure}</p>
+      <p>{lastPublish ? 'Publishing success' : 'Publication failure'}</p>
     </div>
   )
 }
@@ -139,7 +139,7 @@ message and false if they don't referring to the last publication.
 
 ## Examples
 
-**Checkout the simple examples on [Example folder](https://github.com/reactivando/use-pubsub-js/blob/master/example/src/App.js)**
+**Checkout the simple examples on [Example folder](https://github.com/reactivando/use-pubsub-js/blob/main/example/src/App.tsx)**
 
 or
 
@@ -188,7 +188,7 @@ More real examples:
 
 ## License
 
-MIT © [Reactivando](https://github.com/reactivando/use-pubsub-js/blob/master/LICENSE)
+MIT © [Reactivando](https://github.com/reactivando/use-pubsub-js/blob/main/LICENSE)
 
 ---
 

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -12,7 +12,6 @@ overrides:
   js-yaml: ^4.2.0
   minimatch@3: ^3.1.4
   picomatch@4: ^4.0.4
-  yaml: ^2.8.3
 
 importers:
 
@@ -1147,7 +1146,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.8.3
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true

--- a/example/pnpm-workspace.yaml
+++ b/example/pnpm-workspace.yaml
@@ -15,4 +15,3 @@ overrides:
   js-yaml: ^4.2.0
   minimatch@3: ^3.1.4
   picomatch@4: ^4.0.4
-  yaml: ^2.8.3

--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
   "author": "AZagatti",
   "license": "MIT",
   "repository": "reactivando/use-pubsub-js",
+  "homepage": "https://github.com/reactivando/use-pubsub-js#readme",
+  "bugs": "https://github.com/reactivando/use-pubsub-js/issues",
+  "keywords": [
+    "react",
+    "react-hooks",
+    "pubsub",
+    "publish",
+    "subscribe",
+    "hooks"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.cjs",
@@ -52,6 +62,13 @@
       }
     },
     "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "hooks/usePublish": ["./dist/hooks/usePublish.d.ts"],
+      "hooks/useSubscribe": ["./dist/hooks/useSubscribe.d.ts"],
+      "utils/debounce": ["./dist/utils/debounce.d.ts"]
+    }
   },
   "files": [
     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,9 @@ settings:
 
 overrides:
   basic-ftp: ^5.3.1
-  brace-expansion@1: ^1.1.13
-  brace-expansion@2: ^2.0.3
   defu: ^6.1.5
   handlebars: ^4.7.9
   ip-address: ^10.1.1
-  minimatch@3: ^3.1.4
-  minimatch@9: ^9.0.7
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   tar: ^7.5.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,9 @@ minimumReleaseAgeExclude:
 # vitest and tsdown several levels deep.
 overrides:
   basic-ftp: ^5.3.1
-  brace-expansion@1: ^1.1.13
-  brace-expansion@2: ^2.0.3
   defu: ^6.1.5
   handlebars: ^4.7.9
   ip-address: ^10.1.1
-  minimatch@3: ^3.1.4
-  minimatch@9: ^9.0.7
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   tar: ^7.5.16

--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -144,4 +144,49 @@ describe('usePublish', () => {
 
     expect(result.current.lastPublish).toBe(false)
   })
+  it('should publish immediately when isImmediate and isAutomatic are true', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    defaultRender({ isAutomatic: true, isImmediate: true })
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
+  it('should publish after the delay when debounceMs is given as a string', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    defaultRender({ isAutomatic: true, debounceMs: '200' })
+
+    act(() => {
+      vi.advanceTimersByTime(199)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+
+    act(() => {
+      vi.advanceTimersByTime(2)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
+  it('should not publish automatically when message is empty', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    renderHook(() => usePublish({ token, message: '', isAutomatic: true }))
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+  })
 })

--- a/src/hooks/useSubscribe.spec.ts
+++ b/src/hooks/useSubscribe.spec.ts
@@ -166,4 +166,84 @@ describe('useSubscribe', () => {
     expect(handler1).toBeCalledTimes(1)
     expect(handler2).toBeCalledTimes(1)
   })
+
+  it('should resubscribe when isUnsubscribe is toggled back to false', () => {
+    const handler = vi.fn()
+    let isUnsubscribe = false
+
+    const { rerender } = renderHook(() =>
+      useSubscribe({ token, handler, isUnsubscribe }),
+    )
+
+    isUnsubscribe = true
+    rerender()
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+
+    isUnsubscribe = false
+    rerender()
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('should resubscribe to the new token when token changes', () => {
+    const handler = vi.fn()
+    const token2 = 'test2'
+    let currentToken = token
+
+    const { rerender } = renderHook(() =>
+      useSubscribe({ token: currentToken, handler }),
+    )
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+
+    currentToken = token2
+    rerender()
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+
+    act(() => {
+      PubSub.publish(token2, message)
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(2)
+  })
+
+  it('should not duplicate when resubscribe is called while subscribed', () => {
+    const handler = vi.fn()
+
+    const { result } = renderHook(() => useSubscribe({ token, handler }))
+
+    act(() => {
+      result.current.resubscribe()
+    })
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
 })

--- a/src/utils/debounce.spec.ts
+++ b/src/utils/debounce.spec.ts
@@ -96,4 +96,29 @@ describe('debounce', () => {
 
     expect(func).toBeCalledTimes(1)
   })
+
+  it('should reschedule when the timer fires before the full wait elapses', () => {
+    const func = vi.fn()
+    const debounced = debounce(func, 100)
+
+    debounced()
+    vi.advanceTimersByTime(50)
+    debounced()
+    vi.advanceTimersByTime(50)
+
+    expect(func).not.toBeCalled()
+
+    vi.advanceTimersByTime(50)
+
+    expect(func).toBeCalledTimes(1)
+  })
+
+  it('should do nothing when flush is called with no pending timeout', () => {
+    const func = vi.fn()
+    const debounced = debounce(func, 100)
+
+    debounced.flush()
+
+    expect(func).not.toBeCalled()
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,15 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "module": "esnext",
-    "target": "es5",
+    "target": "es2020",
     "lib": [
-      "es6",
-      "dom",
-      "es2016",
-      "es2017"
+      "es2020",
+      "dom"
     ],
     "sourceMap": true,
     "allowJs": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
-    "noImplicitReturns": false,
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Domain 5/5 — Quality pass

Six persona-lens review agents (hooks correctness, tests/QA, packaging/DX, code quality, CI/security, performance) ran in parallel; **every finding was independently verified against the code**. Only verified-safe, behavior-preserving changes are included — **the hook source files are untouched**.

### Implemented (verified SAFE)
**Packaging / types** (verified with attw + publint):
- Add `typesVersions` for the subpath exports → **attw now all-green** (node10/node16/bundler) for every entrypoint; publint clean. Emitted `.d.ts`/`.d.cts` are byte-identical to before.
- Add `keywords` / `homepage` / `bugs` metadata (matches sibling standard).

**tsconfig modernization** (safe — `noEmit: true`, tsdown owns real output; verified emitted types byte-identical + `tsc` clean):
- `target` es5→es2020, `moduleResolution` node→bundler, collapse `lib` to `[es2020, dom]`, drop the now-unneeded `ignoreDeprecations: "6.0"` and redundant `noImplicitReturns: false`.

**Tests** (additive only — each asserts *existing* behavior; **branch coverage 90.9% → 100%**): isImmediate publish, debounceMs-as-string, empty-message skip, isUnsubscribe round-trip, token-change resubscription, resubscribe-while-subscribed, debounce early-reschedule + flush-no-timeout branches.

**CI / supply-chain:**
- Remove dead overrides (root `brace-expansion@1/@2` + `minimatch@3/@9`, example `yaml`) — tree moved past those majors (`pnpm why` confirms); audit stays clean on both.
- Add `--frozen-lockfile` to ci/e2e/pages installs (matches release.yml).
- `e2e-test.yml`: least-privilege `permissions: contents: read`, drop unneeded `fetch-depth: 0`.

**Docs:** README `master`→`main` links, unquoted JSX strings in the usePublish example, example path `App.js`→`App.tsx`.

### Deferred to maintainer (judgment calls / semver-major) — see review notes
- **StrictMode**: `usePublish` `isInitialPublish` double-fires under React StrictMode (no cleanup/guard on the mount-only effect). Fixing needs a ref-guard (changes dev behavior) — design call.
- **`debounceMs` NaN guard**: a non-numeric string collapses the debounce (NaN→setTimeout). Defensive guard proposed; defer since it changes behavior on invalid input.
- **`debounce.flush()`** leaves a stale `timestamp` (dormant — flush unused by the hooks).
- **Public-type cleanups (all semver-major)**: drop `@ts-nocheck`/narrow `debounce<T extends Function>`, `IUsePublish*` vs `UseSubscription*` naming, `Message = any`→`unknown`, `debounceMs: number|string`, remove the undocumented `export default {…}`.
- **`peerDependencies.react: ">17.0.2"`** → `">=17.0.0"` (oddly excludes 17.0.0–17.0.2).
- **CI hardening**: SHA-pin actions, `ci.yml` permissions block (coveralls token scope), remove dead `gh-pages` dep + `deploy` script, MIXED_EXPORTS warning.

### Verification
build ✓ · 27 tests ✓ · **100% branch coverage** · lint ✓ · e2e 2/2 ✓ · audit clean (root + example) · frozen installs ✓ · attw all-green · publint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)