### PR TITLE
fix(usePublish): StrictMode-safe initial publish + debounceMs NaN guard

### DIFF
--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -189,4 +189,23 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(0)
   })
+  it('should fall back to the default delay when debounceMs is not a number', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    defaultRender({ isAutomatic: true, debounceMs: 'not-a-number' })
+
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+
+    act(() => {
+      vi.advanceTimersByTime(2)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
 })

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -1,5 +1,5 @@
 import PubSub from 'pubsub-js'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { debounce } from '../utils/debounce'
 
 export interface IUsePublishResponse {
@@ -25,6 +25,7 @@ export const usePublish = <TokenType extends string | symbol>({
   debounceMs = 300,
 }: IUsePublishParams<TokenType>): IUsePublishResponse => {
   const [lastPublish, setLastPublish] = useState(false)
+  const didInitialPublish = useRef(false)
 
   const publish = useCallback(() => {
     const isPublished = PubSub.publish(token, message)
@@ -32,15 +33,17 @@ export const usePublish = <TokenType extends string | symbol>({
     setLastPublish(isPublished)
   }, [token, message])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount when isInitialPublish is set; the empty dep array is intentional
+  // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount when isInitialPublish is set; the empty dep array and the ref guard keep it single-fire even under StrictMode's double-invoke
   useEffect(() => {
-    if (isInitialPublish) {
+    if (isInitialPublish && !didInitialPublish.current) {
+      didInitialPublish.current = true
       publish()
     }
   }, [])
 
   useEffect(() => {
-    const debouncedPublished = debounce(publish, +debounceMs, isImmediate)
+    const wait = Number.isFinite(+debounceMs) ? +debounceMs : 300
+    const debouncedPublished = debounce(publish, wait, isImmediate)
     if (isAutomatic && message) {
       debouncedPublished()
     }


### PR DESCRIPTION
## Current-release batch — PR A: hook/util robustness fixes

Two small, behavior-preserving robustness fixes to `usePublish` (from the quality-pass deferred list, items #1 and #2). Hook source change is confined to `usePublish.ts`.

### #1 — StrictMode double-fire guard
`isInitialPublish` runs `publish()` in a mount-only `useEffect(fn, [])`. Under React StrictMode (dev), effects double-invoke, so it would publish twice on mount. Added a `useRef` guard so it fires exactly once.
- **No change to normal/production behavior** — the empty-dep effect already fires once; a genuine remount still re-fires via a fresh ref.
- **Honest caveat:** RTL's `renderHook` does **not** enable StrictMode's effect double-invoke (verified with a probe asserting a mount effect runs exactly once), so this can't be pinned by an automated test in this harness. It's a defensive fix for real dev apps wrapped in `<StrictMode>`.

### #2 — `debounceMs` NaN guard
`debounceMs?: number | string` is coerced via `+debounceMs`. A non-numeric string → `NaN` → `setTimeout(…, NaN)` collapses the debounce to ~0ms. Guarded with `Number.isFinite(+debounceMs) ? +debounceMs : 300`.
- Identical for every valid input (number, numeric string, `0`, `undefined`).
- **New test included** that fails on the old code (publishes at t=299 instead of waiting for the 300ms fallback).

### Dropped: #3 (debounce.flush stale timestamp)
On tracing it, `timestamp` is always refreshed on the next `debounced()` call before `later()` can fire, so the proposed bug isn't reachable. Not worth touching the timing logic.

### Verification
28 tests pass · lint ✓ · build ✓ · e2e 2/2 ✓. The NaN test was mutation-checked (fails on unfixed source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)