### PR TITLE
test: pin the pub/sub contract before the internal-module migration

### DIFF
--- a/src/hooks/pubsub-integration.spec.ts
+++ b/src/hooks/pubsub-integration.spec.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react'
+import PubSub from 'pubsub-js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { usePublish } from './usePublish'
+import { useSubscribe } from './useSubscribe'
+
+vi.useFakeTimers()
+
+const token = 'integration-token'
+const message = 'integration-message'
+
+describe('usePublish + useSubscribe integration', () => {
+  afterEach(() => {
+    vi.clearAllTimers()
+    PubSub.clearAllSubscriptions()
+  })
+
+  it('should deliver a publish from usePublish to a useSubscribe handler', () => {
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ token, handler }))
+    const { result } = renderHook(() => usePublish({ token, message }))
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(token, message)
+    expect(result.current.lastPublish).toBe(true)
+  })
+
+  it('should deliver automatic publishes from usePublish to useSubscribe', () => {
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ token, handler }))
+    renderHook(() => usePublish({ token, message, isAutomatic: true }))
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(token, message)
+  })
+})

--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -208,4 +208,73 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(1)
   })
+  it('should set lastPublish to false after the subscriber unsubscribes', () => {
+    const handler = vi.fn()
+    const subscription = PubSub.subscribe(token, handler)
+
+    const { result } = defaultRender()
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(result.current.lastPublish).toBe(true)
+
+    PubSub.unsubscribe(subscription)
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(result.current.lastPublish).toBe(false)
+  })
+  it('should publish only once with isInitialPublish across rerenders', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    const { rerender } = renderHook(
+      (props: { message: string }) =>
+        usePublish({
+          token,
+          message: props.message,
+          isInitialPublish: true,
+        }),
+      { initialProps: { message: 'first' } },
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+
+    act(() => {
+      rerender({ message: 'second' })
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
+  it('should not publish again at the trailing edge when isImmediate is true', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    defaultRender({ isAutomatic: true, isImmediate: true })
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
 })

--- a/src/hooks/useSubscribe.spec.ts
+++ b/src/hooks/useSubscribe.spec.ts
@@ -246,4 +246,101 @@ describe('useSubscribe', () => {
 
     expect(handler).toBeCalledTimes(1)
   })
+
+  it('should deliver the message asynchronously, not during publish', () => {
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ token, handler }))
+
+    publish()
+
+    expect(handler).toBeCalledTimes(0)
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('should call the handler with the published token and message', () => {
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ token, handler }))
+
+    publish()
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toHaveBeenCalledWith(token, message)
+  })
+
+  it('should deliver object payloads by reference', () => {
+    const handler = vi.fn()
+    const payload = { arr: [1, 2, 3], nested: { x: 1 } }
+
+    renderHook(() => useSubscribe({ token, handler }))
+
+    PubSub.publish(token, payload)
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler.mock.calls[0][1]).toBe(payload)
+  })
+
+  it('should deliver to every independent subscriber on the same token', () => {
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    renderHook(() => useSubscribe({ token, handler: handler1 }))
+    renderHook(() => useSubscribe({ token, handler: handler2 }))
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler1).toBeCalledTimes(1)
+    expect(handler2).toBeCalledTimes(1)
+  })
+
+  it('should only unsubscribe the targeted hook, leaving others subscribed', () => {
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+
+    const { result } = renderHook(() =>
+      useSubscribe({ token, handler: handler1 }),
+    )
+    renderHook(() => useSubscribe({ token, handler: handler2 }))
+
+    result.current.unsubscribe()
+
+    act(() => {
+      publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler1).toBeCalledTimes(0)
+    expect(handler2).toBeCalledTimes(1)
+  })
+
+  it('should route messages for a Symbol token', () => {
+    const symbolToken = Symbol('event')
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ token: symbolToken, handler }))
+
+    PubSub.publish(symbolToken, message)
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(1)
+    expect(handler.mock.calls[0][1]).toBe(message)
+  })
 })

--- a/src/utils/debounce.spec.ts
+++ b/src/utils/debounce.spec.ts
@@ -121,4 +121,30 @@ describe('debounce', () => {
 
     expect(func).not.toBeCalled()
   })
+
+  it('should flush with the last pending arguments', () => {
+    const func = vi.fn()
+    const debounced = debounce(func, 100)
+
+    debounced('first')
+    debounced('second')
+    debounced('third')
+    debounced.flush()
+
+    expect(func).toBeCalledTimes(1)
+    expect(func).toHaveBeenCalledWith('third')
+  })
+
+  it('should start a fresh debounce window after clear', () => {
+    const func = vi.fn()
+    const debounced = debounce(func, 100)
+
+    debounced()
+    debounced.clear()
+
+    debounced()
+    vi.advanceTimersByTime(100)
+
+    expect(func).toBeCalledTimes(1)
+  })
 })

--- a/src/utils/debounce.spec.ts
+++ b/src/utils/debounce.spec.ts
@@ -142,9 +142,13 @@ describe('debounce', () => {
     debounced()
     debounced.clear()
 
+    // clear cancelled the pending call (would fail if clear were a no-op)
+    vi.advanceTimersByTime(100)
+    expect(func).not.toBeCalled()
+
+    // a fresh call after clear starts a new window and fires once
     debounced()
     vi.advanceTimersByTime(100)
-
     expect(func).toBeCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Current-release batch — PR C: test-coverage hardening

Adds **behavioral/integration tests** to pin the observable pub/sub contract before the upcoming `pubsub-js` → internal-module migration. Branch/line coverage was already 100%; these guard against a reimplementation silently changing behavior. Driven by a subagent gap analysis; **every test was verified against current behavior** (and the suite was run to confirm green).

### New cross-hook integration spec (`pubsub-integration.spec.ts`)
- `usePublish` actually delivers to a `useSubscribe` handler (manual `publish()` and `isAutomatic`). This was the biggest hole — nothing previously wired the two hooks together.

### `useSubscribe` contract
- **Async delivery**: handler is *not* called during `publish()`, only after the timer tick — guards against a synchronous reimplementation.
- Handler receives the exact `(token, message)` arguments.
- Object payloads delivered **by reference** (not cloned/serialized).
- **All** independent subscribers on a token receive the message.
- `unsubscribe()` affects only the targeted hook, not co-subscribers.
- **Symbol** tokens route correctly.

### `usePublish` contract
- `lastPublish` transitions `true → false` when the subscriber goes away.
- `isInitialPublish` fires exactly once across rerenders.
- `isImmediate` does not double-fire at the trailing edge.

### `debounce`
- `flush()` forwards the last pending arguments.
- a fresh debounce window works after `clear()`.

### Verification
**41 tests** pass (was 28) · **100% branch coverage** · lint ✓ · build ✓ · e2e 2/2 ✓. No source changes — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)