### PR TITLE
chore(test): drop "should" prefixes via should-up + document the convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# use-pubsub-js — agent notes
+
+React hooks (`usePublish`, `useSubscribe`) + a re-exported `PubSub` wrapping
+`pubsub-js`, plus a `debounce` util. Built with tsdown (dual ESM/CJS),
+tested with vitest + @testing-library/react (jsdom), linted/formatted with
+Biome via the ultracite preset, git hooks via lefthook. Package manager:
+pnpm 11 (run via `corepack pnpm …`).
+
+## Testing conventions
+
+- **No `should` prefix in test descriptions.** Write assertive titles —
+  `it('publishes on mount')`, not `it('should publish on mount')`. The
+  bare verb (3rd person) reads as a statement of fact about the code.
+- To normalize existing titles, run [`should-up`](https://github.com/spotify/should-up):
+
+  ```sh
+  pnpm dlx should-up ./src
+  ```
+
+  It strips `should` and conjugates common verbs, but it's an old tool
+  (v1.0.0) and only knows a fixed verb list — it leaves verbs it can't
+  conjugate (e.g. `deliver`, `flush`, `reschedule`, `resubscribe`)
+  untouched, so review its output and fix any stragglers by hand.
+- This convention is **not enforceable by Biome** — there is no lint rule
+  for test-title wording — so it's a review/`should-up` convention, not a
+  CI gate.
+
+## Common commands
+
+```sh
+corepack pnpm test            # vitest (watch); add --run for CI mode
+corepack pnpm test --run --coverage
+corepack pnpm lint            # ultracite check ./src
+corepack pnpm format          # ultracite fix ./src
+corepack pnpm build           # tsdown
+corepack pnpm test:e2e        # build + e2e (CJS/ESM import smoke tests)
+```

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ More real examples:
 | lastPublish | The value is true if you have a subscriber on last publication and false if you don't | boolean    |
 | publish     | A function to manual publish a message                                                | () => void |
 
+## Contributing
+
+Tests use [Vitest](https://vitest.dev) + [Testing Library](https://testing-library.com).
+
+We follow an **assertive test-description style — no `should` prefix**
+(`it('publishes on mount')`, not `it('should publish on mount')`). To
+normalize existing titles, run Spotify's
+[`should-up`](https://github.com/spotify/should-up):
+
+```sh
+pnpm dlx should-up ./src
+```
+
+It strips `should` and conjugates common verbs; for verbs it doesn't know
+you may need a small manual touch-up. (There's no Biome/lint rule for
+test-title wording, so this is a convention, not a CI check.)
+
 ## License
 
 MIT © [Reactivando](https://github.com/reactivando/use-pubsub-js/blob/main/LICENSE)

--- a/src/hooks/pubsub-integration.spec.ts
+++ b/src/hooks/pubsub-integration.spec.ts
@@ -15,7 +15,7 @@ describe('usePublish + useSubscribe integration', () => {
     PubSub.clearAllSubscriptions()
   })
 
-  it('should deliver a publish from usePublish to a useSubscribe handler', () => {
+  it('delivers a publish from usePublish to a useSubscribe handler', () => {
     const handler = vi.fn()
 
     renderHook(() => useSubscribe({ token, handler }))
@@ -31,7 +31,7 @@ describe('usePublish + useSubscribe integration', () => {
     expect(result.current.lastPublish).toBe(true)
   })
 
-  it('should deliver automatic publishes from usePublish to useSubscribe', () => {
+  it('delivers automatic publishes from usePublish to useSubscribe', () => {
     const handler = vi.fn()
 
     renderHook(() => useSubscribe({ token, handler }))

--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -23,7 +23,7 @@ describe('usePublish', () => {
     PubSub.clearAllSubscriptions()
   })
 
-  it('should publish a message when call hook', () => {
+  it('publishes a message when call hook', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -37,7 +37,7 @@ describe('usePublish', () => {
     expect(handler).toBeCalledTimes(1)
     expect(result.current.lastPublish).toBe(true)
   })
-  it('should only publish when invoke a returned function', () => {
+  it('only publishes when invoke a returned function', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -52,7 +52,7 @@ describe('usePublish', () => {
     expect(handler).toBeCalledTimes(1)
     expect(result.current.lastPublish).toBe(true)
   })
-  it('should publish again after 300ms when message changes', () => {
+  it('publishes again after 300ms when message changes', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -84,7 +84,7 @@ describe('usePublish', () => {
     expect(handler).toBeCalledTimes(2)
     expect(result.current.lastPublish).toBe(true)
   })
-  it('should publish again after custom ms when message changes', () => {
+  it('publishes again after custom ms when message changes', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -117,7 +117,7 @@ describe('usePublish', () => {
     expect(handler).toBeCalledTimes(2)
     expect(result.current.lastPublish).toBe(true)
   })
-  it('should not publish again when have debounce pending then unmount', () => {
+  it('does not publish again when have debounce pending then unmount', () => {
     const handler = vi.fn()
     const localMessage = 'message'
 
@@ -135,7 +135,7 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(0)
   })
-  it('should return false on lastPublish when not have a subscribe', () => {
+  it('returns false on lastPublish when not have a subscribe', () => {
     const { result } = defaultRender()
 
     act(() => {
@@ -144,7 +144,7 @@ describe('usePublish', () => {
 
     expect(result.current.lastPublish).toBe(false)
   })
-  it('should publish immediately when isImmediate and isAutomatic are true', () => {
+  it('publishes immediately when isImmediate and isAutomatic are true', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -157,7 +157,7 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(1)
   })
-  it('should publish after the delay when debounceMs is given as a string', () => {
+  it('publishes after the delay when debounceMs is given as a string', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -176,7 +176,7 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(1)
   })
-  it('should not publish automatically when message is empty', () => {
+  it('does not publish automatically when message is empty', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -189,7 +189,7 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(0)
   })
-  it('should fall back to the default delay when debounceMs is not a number', () => {
+  it('falls back to the default delay when debounceMs is not a number', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -208,7 +208,7 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(1)
   })
-  it('should set lastPublish to false after the subscriber unsubscribes', () => {
+  it('sets lastPublish to false after the subscriber unsubscribes', () => {
     const handler = vi.fn()
     const subscription = PubSub.subscribe(token, handler)
 
@@ -230,7 +230,7 @@ describe('usePublish', () => {
 
     expect(result.current.lastPublish).toBe(false)
   })
-  it('should publish only once with isInitialPublish across rerenders', () => {
+  it('publishes only once with isInitialPublish across rerenders', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)
@@ -258,7 +258,7 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(1)
   })
-  it('should not publish again at the trailing edge when isImmediate is true', () => {
+  it('does not publish again at the trailing edge when isImmediate is true', () => {
     const handler = vi.fn()
 
     PubSub.subscribe(token, handler)

--- a/src/hooks/useSubscribe.spec.ts
+++ b/src/hooks/useSubscribe.spec.ts
@@ -16,7 +16,7 @@ describe('useSubscribe', () => {
     PubSub.clearAllSubscriptions()
   })
 
-  it('should receive a published message', () => {
+  it('receives a published message', () => {
     const handler = vi.fn()
 
     renderHook(() => useSubscribe({ token, handler }))
@@ -30,7 +30,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
     expect(isPublished).toBe(true)
   })
-  it('should unsubscribe when isUnsubscribe is changed to true', () => {
+  it('unsubscribes when isUnsubscribe is changed to true', () => {
     const handler = vi.fn()
     let isUnsubscribe = false
 
@@ -59,7 +59,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
     expect(isPublishedChanged).toBe(false)
   })
-  it('should unsubscribe when invoke unsubscribe function', () => {
+  it('unsubscribes when invoke unsubscribe function', () => {
     const handler = vi.fn()
 
     const { result } = renderHook(() => useSubscribe({ token, handler }))
@@ -84,7 +84,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
     expect(isPublishedChanged).toBe(false)
   })
-  it('should resubscribe after unsubscribe', () => {
+  it('resubscribes after unsubscribe', () => {
     const handler = vi.fn()
 
     const { result } = renderHook(() => useSubscribe({ token, handler }))
@@ -111,7 +111,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
     expect(isPublishedChanged).toBe(true)
   })
-  it('should unsubscribe when hook is unmounted', () => {
+  it('unsubscribes when hook is unmounted', () => {
     const handler = vi.fn()
 
     const { unmount } = renderHook(() => useSubscribe({ token, handler }))
@@ -137,7 +137,7 @@ describe('useSubscribe', () => {
     expect(isPublishedChanged).toBe(false)
   })
 
-  it('should not call the old handler when the handler changes', () => {
+  it('does not call the old handler when the handler changes', () => {
     const handler1 = vi.fn()
     const handler2 = vi.fn()
 
@@ -167,7 +167,7 @@ describe('useSubscribe', () => {
     expect(handler2).toBeCalledTimes(1)
   })
 
-  it('should resubscribe when isUnsubscribe is toggled back to false', () => {
+  it('resubscribes when isUnsubscribe is toggled back to false', () => {
     const handler = vi.fn()
     let isUnsubscribe = false
 
@@ -196,7 +196,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
   })
 
-  it('should resubscribe to the new token when token changes', () => {
+  it('resubscribes to the new token when token changes', () => {
     const handler = vi.fn()
     const token2 = 'test2'
     let currentToken = token
@@ -230,7 +230,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(2)
   })
 
-  it('should not duplicate when resubscribe is called while subscribed', () => {
+  it('does not duplicate when resubscribe is called while subscribed', () => {
     const handler = vi.fn()
 
     const { result } = renderHook(() => useSubscribe({ token, handler }))
@@ -247,7 +247,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
   })
 
-  it('should deliver the message asynchronously, not during publish', () => {
+  it('delivers the message asynchronously, not during publish', () => {
     const handler = vi.fn()
 
     renderHook(() => useSubscribe({ token, handler }))
@@ -263,7 +263,7 @@ describe('useSubscribe', () => {
     expect(handler).toBeCalledTimes(1)
   })
 
-  it('should call the handler with the published token and message', () => {
+  it('calls the handler with the published token and message', () => {
     const handler = vi.fn()
 
     renderHook(() => useSubscribe({ token, handler }))
@@ -277,7 +277,7 @@ describe('useSubscribe', () => {
     expect(handler).toHaveBeenCalledWith(token, message)
   })
 
-  it('should deliver object payloads by reference', () => {
+  it('delivers object payloads by reference', () => {
     const handler = vi.fn()
     const payload = { arr: [1, 2, 3], nested: { x: 1 } }
 
@@ -292,7 +292,7 @@ describe('useSubscribe', () => {
     expect(handler.mock.calls[0][1]).toBe(payload)
   })
 
-  it('should deliver to every independent subscriber on the same token', () => {
+  it('delivers to every independent subscriber on the same token', () => {
     const handler1 = vi.fn()
     const handler2 = vi.fn()
 
@@ -308,7 +308,7 @@ describe('useSubscribe', () => {
     expect(handler2).toBeCalledTimes(1)
   })
 
-  it('should only unsubscribe the targeted hook, leaving others subscribed', () => {
+  it('only unsubscribes the targeted hook, leaving others subscribed', () => {
     const handler1 = vi.fn()
     const handler2 = vi.fn()
 
@@ -328,7 +328,7 @@ describe('useSubscribe', () => {
     expect(handler2).toBeCalledTimes(1)
   })
 
-  it('should route messages for a Symbol token', () => {
+  it('routes messages for a Symbol token', () => {
     const symbolToken = Symbol('event')
     const handler = vi.fn()
 

--- a/src/utils/debounce.spec.ts
+++ b/src/utils/debounce.spec.ts
@@ -10,7 +10,7 @@ describe('debounce', () => {
     vi.useRealTimers()
   })
 
-  it('should debounce a function', () => {
+  it('debounces a function', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -25,7 +25,7 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
-  it('should call the function with the last arguments', () => {
+  it('calls the function with the last arguments', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -38,7 +38,7 @@ describe('debounce', () => {
     expect(func).toHaveBeenCalledWith(3)
   })
 
-  it('should call the function immediately', () => {
+  it('calls the function immediately', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100, true)
 
@@ -47,7 +47,7 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
-  it('should not call the function again after immediate call', () => {
+  it('does not call the function again after immediate call', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100, true)
 
@@ -61,7 +61,7 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
-  it('should clear the timeout', () => {
+  it('clears the timeout', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -73,7 +73,7 @@ describe('debounce', () => {
     expect(func).not.toBeCalled()
   })
 
-  it('should flush the function', () => {
+  it('flushes the function', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -83,7 +83,7 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
-  it('should not call the function twice after flush', () => {
+  it('does not call the function twice after flush', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -97,7 +97,7 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
-  it('should reschedule when the timer fires before the full wait elapses', () => {
+  it('reschedules when the timer fires before the full wait elapses', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -113,7 +113,7 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
-  it('should do nothing when flush is called with no pending timeout', () => {
+  it('does nothing when flush is called with no pending timeout', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -122,7 +122,7 @@ describe('debounce', () => {
     expect(func).not.toBeCalled()
   })
 
-  it('should flush with the last pending arguments', () => {
+  it('flushes with the last pending arguments', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 
@@ -135,7 +135,7 @@ describe('debounce', () => {
     expect(func).toHaveBeenCalledWith('third')
   })
 
-  it('should start a fresh debounce window after clear', () => {
+  it('starts a fresh debounce window after clear', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)
 


### PR DESCRIPTION
## Current-release batch — PR D: should-up test descriptions + docs

Per request: apply [Spotify's `should-up`](https://github.com/spotify/should-up) to the test suite and document it for agents + humans.

### What it does
- Ran `should-up ./src` to convert test titles to the assertive, "should"-free style (`it('publishes on mount')` instead of `it('should publish on mount')`).
- **should-up is old (v1.0.0, 2022) and only conjugates a fixed verb list** — it left verbs it doesn't know (`deliver`, `flush`, `reschedule`, `resubscribe`, `receive`, `route`, and `"should only …"`) untouched. I normalized those 17 stragglers by hand so every title is consistently "should"-free.
- **Description strings only — no test logic changed.** 41 tests still pass.

### Docs (the "reference for agents and humans" ask)
- **`CLAUDE.md`** (new) — agent notes: the no-`should` testing convention, how to run should-up + its verb-list limitation, and common commands.
- **README "Contributing"** — same convention for humans.
- Both note that **Biome can't enforce test-title wording** (no such rule), so this is a convention applied via should-up, not a CI gate.

### Verification
41 tests pass · lint ✓ · build ✓ · e2e 2/2 ✓. (`CLAUDE.md`/README aren't linted or published — Biome scopes to `./src`, `files` is `["dist"]`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)