### PR TITLE
chore: drop aged-out vite minimumReleaseAge excludes

### DIFF
--- a/example/pnpm-workspace.yaml
+++ b/example/pnpm-workspace.yaml
@@ -1,10 +1,5 @@
 allowBuilds:
   esbuild: true
-# vite 8.1.0 and @vitejs/plugin-react 6.0.3 are still inside pnpm 11's
-# default minimumReleaseAge window; exclude them until they age out.
-minimumReleaseAgeExclude:
-  - '@vitejs/plugin-react@6.0.3'
-  - vite@8.1.0
 # Transitive security fixes (dev-only deps pulled in by eslint, vite
 # and @vitejs/plugin-react). Forced to patched versions.
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
 allowBuilds:
   esbuild: true
   lefthook: true
-# vite 8.1.0 is still inside pnpm 11's default minimumReleaseAge window;
-# exclude it so installs resolve until it ages out.
-minimumReleaseAgeExclude:
-  - vite@8.1.0
 # Transitive security fixes (all dev-only deps). Forced to patched
 # versions via overrides because they're pulled in by release-it,
 # vitest and tsdown several levels deep.


### PR DESCRIPTION
## #14 — remove the now-unnecessary release-age excludes

`vite@8.1.0` (root + example) and `@vitejs/plugin-react@6.0.3` (example) were added to pnpm 11's `minimumReleaseAgeExclude` because they were freshly published and otherwise blocked by the default release-age gate. They've since aged past the window, so the excludes are no longer needed — removed from both `pnpm-workspace.yaml` files.

### Verification
- Frozen installs (CI parity) pass on **both** root and example *without* the excludes — pnpm's supply-chain policy check now accepts the versions.
- **Lockfiles unchanged** (the excludes were only gating config, not resolution).
- build ✓ · tests 41 ✓ · lint ✓ · e2e 2/2 ✓ · `pnpm audit` clean (root + example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)