### PR TITLE
feat(v2-M2): swap hooks to the internal pub/sub module (zero runtime deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
     - name: Check linting
       run: pnpm lint
 
+    - name: Build library and example
+      run: |
+        pnpm build
+        pnpm --prefix ./example build
+
     - name: Coveralls
       uses: coverallsapp/github-action@v2
       with:

--- a/example/src/service/publish.ts
+++ b/example/src/service/publish.ts
@@ -1,4 +1,4 @@
-import PubSub from 'pubsub-js'
+import { PubSub } from 'use-pubsub-js'
 
 export const PublishService = {
   interval: undefined as ReturnType<typeof setInterval> | undefined,

--- a/package.json
+++ b/package.json
@@ -65,9 +65,15 @@
   },
   "typesVersions": {
     "*": {
-      "hooks/usePublish": ["./dist/hooks/usePublish.d.ts"],
-      "hooks/useSubscribe": ["./dist/hooks/useSubscribe.d.ts"],
-      "utils/debounce": ["./dist/utils/debounce.d.ts"]
+      "hooks/usePublish": [
+        "./dist/hooks/usePublish.d.ts"
+      ],
+      "hooks/useSubscribe": [
+        "./dist/hooks/useSubscribe.d.ts"
+      ],
+      "utils/debounce": [
+        "./dist/utils/debounce.d.ts"
+      ]
     }
   },
   "files": [
@@ -90,9 +96,6 @@
     "test:e2e": "pnpm build && cd e2e && pnpm install --ignore-workspace && pnpm test",
     "release": "release-it"
   },
-  "dependencies": {
-    "pubsub-js": "^1.9.5"
-  },
   "peerDependencies": {
     "react": ">=17.0.0"
   },
@@ -105,6 +108,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "jsdom": "^29.1.1",
     "lefthook": "^2.1.9",
+    "pubsub-js": "^1.9.5",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "release-it": "^20.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,10 +18,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      pubsub-js:
-        specifier: ^1.9.5
-        version: 1.9.5
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.1
@@ -47,6 +43,9 @@ importers:
       lefthook:
         specifier: ^2.1.9
         version: 2.1.9
+      pubsub-js:
+        specifier: ^1.9.5
+        version: 1.9.5
       react:
         specifier: ^19.2.7
         version: 19.2.7

--- a/src/hooks/pubsub-integration.spec.ts
+++ b/src/hooks/pubsub-integration.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
-import PubSub from 'pubsub-js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PubSub } from '../pubsub'
 import { usePublish } from './usePublish'
 import { useSubscribe } from './useSubscribe'
 

--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
-import PubSub from 'pubsub-js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PubSub } from '../pubsub'
 import { usePublish } from './usePublish'
 
 vi.useFakeTimers()

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -1,5 +1,5 @@
-import PubSub from 'pubsub-js'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { PubSub } from '../pubsub'
 import { debounce } from '../utils/debounce'
 
 export interface IUsePublishResponse {
@@ -52,5 +52,5 @@ export const usePublish = <TokenType extends string | symbol>({
     }
   }, [publish, isImmediate, isAutomatic, debounceMs, message])
 
-  return { lastPublish, publish }
+  return useMemo(() => ({ lastPublish, publish }), [lastPublish, publish])
 }

--- a/src/hooks/useSubscribe.spec.ts
+++ b/src/hooks/useSubscribe.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
-import PubSub from 'pubsub-js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PubSub } from '../pubsub'
 import { useSubscribe } from './useSubscribe'
 
 vi.useFakeTimers()

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -1,7 +1,7 @@
-import PubSub from 'pubsub-js'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { PubSub } from '../pubsub'
 
-// biome-ignore lint/suspicious/noExplicitAny: pubsub-js delivers untyped message payloads
+// biome-ignore lint/suspicious/noExplicitAny: the bus delivers untyped message payloads
 type Message = any
 
 export interface UseSubscriptionResponse {
@@ -27,7 +27,7 @@ export const useSubscribe = <TokenType extends string | symbol>({
     handlerRef.current = handler
   })
 
-  const internalHandler = useCallback((msg: string, data: Message) => {
+  const internalHandler = useCallback((msg: string | symbol, data: Message) => {
     handlerRef.current(msg as TokenType, data)
   }, [])
 
@@ -53,5 +53,8 @@ export const useSubscribe = <TokenType extends string | symbol>({
     return unsubscribe
   }, [isUnsubscribe, token, resubscribe, unsubscribe])
 
-  return { unsubscribe, resubscribe }
+  return useMemo(
+    () => ({ unsubscribe, resubscribe }),
+    [unsubscribe, resubscribe],
+  )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import PubSub from 'pubsub-js'
 import { usePublish } from './hooks/usePublish'
 import { useSubscribe } from './hooks/useSubscribe'
+import { PubSub } from './pubsub'
 
 export { PubSub, usePublish, useSubscribe }
 

--- a/src/pubsub-contract.spec.ts
+++ b/src/pubsub-contract.spec.ts
@@ -199,10 +199,19 @@ describe('PubSub contract', () => {
       expect(handler).toBeCalledTimes(1)
     })
 
-    // pubsub-js stringifies symbols, so two distinct Symbol('x') COLLIDE today.
-    // The v2 internal module keys by identity; activate this on the module in M1.
-    it.todo(
-      'does NOT cross-deliver between two distinct Symbol("x") (v2 module)',
-    )
+    // The internal module keys symbols by identity (pubsub-js stringified them,
+    // so two distinct Symbol('x') used to collide). Activated post-swap (M2).
+    it('does NOT cross-deliver between two distinct Symbol("x")', () => {
+      const a = vi.fn()
+      const b = vi.fn()
+      PubSub.subscribe(Symbol('x'), a)
+      PubSub.subscribe(Symbol('x'), b)
+
+      PubSub.publish(Symbol('x'), 'm')
+      flush()
+
+      expect(a).toBeCalledTimes(0)
+      expect(b).toBeCalledTimes(0)
+    })
   })
 })


### PR DESCRIPTION
## v2 migration — M2: wire the hooks (the swap)

The behavior swap. `usePublish`/`useSubscribe`/`index` now use the internal `../pubsub` module; **`pubsub-js` removed from runtime dependencies** (kept as a devDependency for the parity test). The package now has **zero runtime dependencies**.

### Changes
- Hooks `import { PubSub } from '../pubsub'`. `internalHandler` widened to receive the **original token** (`string | symbol`) — the `as TokenType` cast is now truthful and symbol subscribers get the real symbol.
- **`useMemo` both hook return objects** (R3 / 08-V3) — stable identity avoids the exhaustive-deps infinite-loop footgun.
- Spec oracles repointed `pubsub-js` → `../pubsub` (same singleton the hooks use); the **symbol-identity contract test is now active** (was `it.todo`) and passes against the identity-keyed bus.
- **example** `import { PubSub } from 'use-pubsub-js'` (08-V1) + a new **ci.yml step builds the library + example** so a broken example blocks merge.

### Verification (behavior equivalence is the point)
**All 105 tests pass against the internal module** (the prior pubsub-js-backed suite + the M0 contract + M1 isolation/parity) · 100% coverage · lint ✓ · tsc ✓ · build ✓ · **example build ✓** · e2e 2/2 ✓ · **audit clean (0 runtime deps)** · publint clean · attw all-green.

`Message` stays `any` here (tightened to `unknown` in M4, with the other type-breaking cleanups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)