### PR TITLE
feat(v2-M4)!: semver-major type cleanups

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -42,23 +42,16 @@
   },
   "overrides": [
     {
-      // Public-API barrel: intentionally re-exports PubSub from pubsub-js
-      // alongside the hooks (documented in the README).
+      // Public-API barrel: the package entry intentionally re-exports the
+      // hooks, PubSub/createPubSub and the public types.
       "includes": ["src/index.ts"],
-      "linter": { "rules": { "style": { "noExportedImports": "off" } } }
+      "linter": { "rules": { "performance": { "noBarrelFile": "off" } } }
     },
     {
-      // Vendored debounce algorithm (kept under @ts-nocheck). Its function
-      // expressions rely on dynamic `this`, so converting them to arrows
-      // would change behavior — keep the lint rules off for this file.
+      // Vendored debounce algorithm: the generic callable constraint
+      // `<T extends (...args: any[]) => any>` and `func.apply` need `any`.
       "includes": ["src/utils/debounce.ts"],
-      "linter": {
-        "rules": {
-          "complexity": { "noBannedTypes": "off", "useArrowFunction": "off" },
-          "style": { "useBlockStatements": "off" },
-          "suspicious": { "noExplicitAny": "off" }
-        }
-      }
+      "linter": { "rules": { "suspicious": { "noExplicitAny": "off" } } }
     }
   ]
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { usePublish, useSubscribe } from 'use-pubsub-js'
 
-import { Token, TokenTwo, TokenThree, TokenFour } from './service/constants'
+import { Token, TokenFour, TokenThree, TokenTwo } from './service/constants'
 import { PublishService } from './service/publish'
 
 PublishService.publish(Token)
@@ -20,10 +20,10 @@ const ManualExternalMessages = () => {
     <div>
       <h2>Manual external messages received:</h2>
       <p>{subscriptionCounter}</p>
-      <button type="button" onClick={unsubscribe}>
+      <button onClick={unsubscribe} type="button">
         Unsubscribe
       </button>
-      <button type="button" onClick={resubscribe}>
+      <button onClick={resubscribe} type="button">
         Resubscribe
       </button>
     </div>
@@ -44,7 +44,7 @@ const AutoExternalMessages = () => {
     <div>
       <h2>Auto external messages received:</h2>
       <p>{subscriptionCounter}</p>
-      <button type="button" onClick={() => setIsUnsubscribe(s => !s)}>
+      <button onClick={() => setIsUnsubscribe(s => !s)} type="button">
         Change isUnsubscribe
       </button>
     </div>
@@ -56,7 +56,7 @@ const ManualPublishMessages = () => {
 
   return (
     <div>
-      <button type="button" onClick={publish}>
+      <button onClick={publish} type="button">
         Publish
       </button>
     </div>
@@ -92,9 +92,9 @@ const AutoPublishMessages = () => {
   return (
     <div>
       <input
+        onChange={e => setMessage(e.target.value)}
         type="text"
         value={message}
-        onChange={e => setMessage(e.target.value)}
       />
     </div>
   )
@@ -104,9 +104,9 @@ const ReceiveAutoPublish = () => {
   const [subscriptionCounter, setSubscriptionCounter] = useState(0)
   const [lastMessage, setLastMessage] = useState('')
 
-  const handler = (_message: string, data: string) => {
+  const handler = (_message: string, data: unknown) => {
     setSubscriptionCounter(c => c + 1)
-    setLastMessage(data)
+    setLastMessage(String(data))
   }
 
   useSubscribe({ token: TokenFour, handler })
@@ -129,36 +129,34 @@ const FailPublish = () => {
   return (
     <div>
       {lastPublish ? <p>Publishing success</p> : <p>Publication failure</p>}
-      <button type="button" onClick={publish}>
+      <button onClick={publish} type="button">
         Publish
       </button>
     </div>
   )
 }
 
-const App = () => {
-  return (
-    <div className="app">
-      <div>
-        <h1>External section</h1>
-        <AutoExternalMessages />
-        <ManualExternalMessages />
-      </div>
-      <div>
-        <h1>Manual section</h1>
-        <ReceiveManualPublish />
-        <ManualPublishMessages />
-      </div>
-      <div>
-        <h1>Automatic section</h1>
-        <ReceiveAutoPublish />
-        <AutoPublishMessages />
-      </div>
-      <div>
-        <h1>Fail section</h1>
-        <FailPublish />
-      </div>
+const App = () => (
+  <div className="app">
+    <div>
+      <h1>External section</h1>
+      <AutoExternalMessages />
+      <ManualExternalMessages />
     </div>
-  )
-}
+    <div>
+      <h1>Manual section</h1>
+      <ReceiveManualPublish />
+      <ManualPublishMessages />
+    </div>
+    <div>
+      <h1>Automatic section</h1>
+      <ReceiveAutoPublish />
+      <AutoPublishMessages />
+    </div>
+    <div>
+      <h1>Fail section</h1>
+      <FailPublish />
+    </div>
+  </div>
+)
 export default App

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { PubSub } from '../pubsub'
 import { debounce } from '../utils/debounce'
 
-export interface IUsePublishResponse {
+export interface UsePublishResponse {
   lastPublish: boolean
   publish: () => void
 }
 
-export interface IUsePublishParams<TokenType extends string | symbol> {
+export interface UsePublishParams<TokenType extends string | symbol> {
   debounceMs?: number | string
   isAutomatic?: boolean
   isImmediate?: boolean
@@ -23,7 +23,7 @@ export const usePublish = <TokenType extends string | symbol>({
   isInitialPublish = false,
   isImmediate = false,
   debounceMs = 300,
-}: IUsePublishParams<TokenType>): IUsePublishResponse => {
+}: UsePublishParams<TokenType>): UsePublishResponse => {
   const [lastPublish, setLastPublish] = useState(false)
   const didInitialPublish = useRef(false)
 

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { PubSub } from '../pubsub'
 
-// biome-ignore lint/suspicious/noExplicitAny: the bus delivers untyped message payloads
-type Message = any
+type Message = unknown
 
 export interface UseSubscriptionResponse {
   resubscribe: () => void

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+// biome-ignore lint/performance/noNamespaceImport: asserting the full module shape (named exports + absence of a default export)
+import * as api from './index'
+
+describe('package entry (src/index)', () => {
+  it('exposes the named public API', () => {
+    expect(typeof api.usePublish).toBe('function')
+    expect(typeof api.useSubscribe).toBe('function')
+    expect(typeof api.createPubSub).toBe('function')
+    expect(api.PubSub).toBeDefined()
+    expect(typeof api.PubSub.subscribe).toBe('function')
+  })
+
+  it('has no default export (removed in v2)', () => {
+    expect((api as Record<string, unknown>).default).toBeUndefined()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
-import { usePublish } from './hooks/usePublish'
-import { useSubscribe } from './hooks/useSubscribe'
-import { PubSub } from './pubsub'
-
-export { PubSub, usePublish, useSubscribe }
-
-export default { PubSub, useSubscribe, usePublish }
+export type { UsePublishParams, UsePublishResponse } from './hooks/usePublish'
+export { usePublish } from './hooks/usePublish'
+export type {
+  UseSubscriptionParams,
+  UseSubscriptionResponse,
+} from './hooks/useSubscribe'
+export { useSubscribe } from './hooks/useSubscribe'
+export type {
+  EventMap,
+  Listener,
+  PubSubBus,
+  Token,
+  TypedPubSub,
+} from './pubsub'
+export { createPubSub, PubSub } from './pubsub'

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,15 +1,13 @@
-// @ts-nocheck
-
-export function debounce<T extends Function>(
+export function debounce<T extends (...args: any[]) => any>(
   func: T,
   wait = 100,
   immediate = false,
 ) {
-  let timeout: ReturnType<typeof setTimeout> | null
-  let args: unknown
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  let args: Parameters<T> | null = null
   let context: unknown
-  let timestamp: number
-  let result: unknown
+  let timestamp = 0
+  let result: ReturnType<T> | undefined
 
   function later() {
     const last = Date.now() - timestamp
@@ -19,7 +17,7 @@ export function debounce<T extends Function>(
     } else {
       timeout = null
       if (!immediate) {
-        result = func.apply(context, args as any)
+        result = func.apply(context, args as Parameters<T>)
         context = args = null
       }
     }
@@ -30,7 +28,9 @@ export function debounce<T extends Function>(
     args = _args
     timestamp = Date.now()
     const callNow = immediate && !timeout
-    if (!timeout) timeout = setTimeout(later, wait)
+    if (!timeout) {
+      timeout = setTimeout(later, wait)
+    }
     if (callNow) {
       result = func.apply(context, args)
       context = args = null
@@ -39,16 +39,16 @@ export function debounce<T extends Function>(
     return result
   }
 
-  debounced.clear = function () {
+  debounced.clear = () => {
     if (timeout) {
       clearTimeout(timeout)
       timeout = null
     }
   }
 
-  debounced.flush = function () {
+  debounced.flush = () => {
     if (timeout) {
-      result = func.apply(context, args as any)
+      result = func.apply(context, args as Parameters<T>)
       context = args = null
 
       clearTimeout(timeout)


### PR DESCRIPTION
## v2 migration — M4: type cleanups (breaking)

Bundles the deferred semver-major type changes for v2.0.0.

- **`Message` `any` → `unknown`** in the `useSubscribe` handler — handlers must narrow/guard the payload.
- **Rename** `IUsePublishResponse`/`IUsePublishParams` → `UsePublishResponse`/`UsePublishParams` (match the `UseSubscription*` naming).
- **Remove the undocumented default export** from `src/index.ts` (named exports only); also clears the rolldown `MIXED_EXPORTS` warning. Added `src/index.spec.ts` asserting the named API exists and **`default` is `undefined`**.
- **`debounce.ts`**: drop `@ts-nocheck`; narrow the generic to `<T extends (...args: any[]) => any>` and type the internals (`args: Parameters<T> | null`, `result: ReturnType<T> | undefined`); `clear`/`flush` are arrows. Slimmed its Biome override to just `noExplicitAny`.
- Additive: the barrel now surfaces the public types + `createPubSub`. `debounceMs: number | string` kept (decided).

### Verification
107 tests · 100% coverage · tsc ✓ · lint ✓ · build ✓ · e2e 2/2 ✓ · attw all-green · publint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)