### PR TITLE
docs: v2 migration plan & design record (research, reviews, decisions)

### DIFF
--- a/docs/migration-v2/01-api-design.md
+++ b/docs/migration-v2/01-api-design.md
@@ -30,7 +30,9 @@ Plus `clearAllSubscriptions()` used by every test's `afterEach`.
 // src/pubsub/index.ts
 export type Token = string
 
-export type Listener<T = unknown> = (token: string, data: T) => void
+// NOTE (per 08-V2): the handler receives the ORIGINAL token (string | symbol),
+// not its string form — so identity-keyed symbol tokens reach the handler intact.
+export type Listener<T = unknown> = (token: string | symbol, data: T) => void
 
 export interface PubSubBus {
   /** async delivery via setTimeout(0); returns true iff >=1 subscriber. */
@@ -162,10 +164,11 @@ function unsubscribe(value) {
 function publish(token, data) {
   const m = channels.get(token)
   if (!m || m.size === 0) return false
-  const snapshot = [...m.values()]
+  const snapshot = [...m.values()]       // snapshot: subs added mid-dispatch don't fire now
   setTimeout(() => {
     for (const fn of snapshot) {
-      try { fn(String(token), data) } catch (err) { setTimeout(() => { throw err }, 0) }
+      // deliver the ORIGINAL token (string | symbol), not String(token) — see 08-V2
+      try { fn(token, data) } catch (err) { setTimeout(() => { throw err }, 0) }
     }
   }, 0)
   return true

--- a/docs/migration-v2/01-api-design.md
+++ b/docs/migration-v2/01-api-design.md
@@ -1,0 +1,176 @@
+# 01 — Internal pub/sub module API design
+
+New module lives at `src/pubsub/index.ts` (the build globs pick it up; no
+tsdown/tsconfig change needed). It exposes three things, layered from
+"drop-in" to "modern":
+
+1. **`PubSub`** — a lean singleton, backward-compatible with how the library
+   re-exports it today. This is what the hooks use internally and what existing
+   `import { PubSub } from 'use-pubsub-js'` consumers keep using.
+2. **`createPubSub<EventMap>()`** — the *better* API: a typed factory (mitt /
+   nanoevents style) so app code gets fully-typed channels instead of `any`.
+3. **`on(token, handler, { signal? })`** — ergonomic subscribe that returns an
+   unsubscribe function and supports `AbortSignal` (additive sugar).
+
+## What the hooks actually require (the hard floor)
+
+From the source, the hooks only need:
+
+```ts
+publish(token, data): boolean          // usePublish — drives lastPublish
+subscribe(token, handler): Token       // useSubscribe — stored in a ref
+unsubscribe(token): void               // useSubscribe — cleanup / isUnsubscribe
+```
+
+Plus `clearAllSubscriptions()` used by every test's `afterEach`.
+
+## Proposed public surface
+
+```ts
+// src/pubsub/index.ts
+export type Token = string
+
+export type Listener<T = unknown> = (token: string, data: T) => void
+
+export interface PubSubBus {
+  /** async delivery via setTimeout(0); returns true iff >=1 subscriber. */
+  publish<T = unknown>(token: string | symbol, data?: T): boolean
+  /** returns an opaque string token to pass to unsubscribe(). */
+  subscribe<T = unknown>(token: string | symbol, handler: Listener<T>): Token
+  /** ergonomic: returns an unsubscribe fn; optional AbortSignal teardown. */
+  on<T = unknown>(
+    token: string | symbol,
+    handler: Listener<T>,
+    options?: { signal?: AbortSignal }
+  ): () => void
+  /** fires at most once, then auto-unsubscribes. */
+  subscribeOnce<T = unknown>(token: string | symbol, handler: Listener<T>): Token
+  /** unsubscribe by token, or by handler reference. */
+  unsubscribe(value: Token | Listener): boolean
+  clearAllSubscriptions(): void
+}
+
+export const PubSub: PubSubBus
+
+// The typed "better" API
+export type EventMap = Record<string | symbol, unknown>
+export interface TypedPubSub<E extends EventMap> {
+  publish<K extends keyof E>(token: K, data: E[K]): boolean
+  subscribe<K extends keyof E>(token: K, handler: (token: K, data: E[K]) => void): Token
+  on<K extends keyof E>(token: K, handler: (token: K, data: E[K]) => void, options?: { signal?: AbortSignal }): () => void
+  subscribeOnce<K extends keyof E>(token: K, handler: (token: K, data: E[K]) => void): Token
+  unsubscribe(value: Token | ((token: never, data: never) => void)): boolean
+  clearAllSubscriptions(): void
+}
+export function createPubSub<E extends EventMap = EventMap>(): TypedPubSub<E>
+```
+
+`PubSub` is just `createPubSub()` with the default (untyped) event map, so there
+is one implementation.
+
+### Consumer usage (the typed win)
+
+```ts
+import { createPubSub } from 'use-pubsub-js/pubsub'
+
+type AppEvents = {
+  'user:login': { userId: string }
+  'cart:update': { itemCount: number }
+}
+export const bus = createPubSub<AppEvents>()
+
+bus.publish('user:login', { userId: '42' })          // payload type-checked
+bus.subscribe('cart:update', (_t, data) => data.itemCount) // data: { itemCount: number }
+```
+
+## Mapping onto the hooks (no public hook-API change)
+
+- `useSubscribe`: swap `import PubSub from 'pubsub-js'` → `import { PubSub } from '../pubsub'`.
+  `subscriptionToken` ref stays `string | null` (subscribe returns a string token).
+  The `Message = any` alias becomes `unknown` (see §types). Optionally add an
+  additive second generic `Events` (defaulting to the untyped map) so callers
+  *can* get typed handlers without any required change — **deferred to ideas**
+  unless review wants it in v2.
+- `usePublish`: swap the import only. `publish()` still returns `boolean`.
+- `src/index.ts`: re-export `PubSub` (unchanged name) **plus** `createPubSub`
+  and the types. Remove the `import PubSub from 'pubsub-js'`.
+
+## Kept vs dropped vs decided (relative to pubsub-js)
+
+**KEEP (required or low-cost, documented):**
+- `publish` (async), `subscribe` (→ string token), `unsubscribe(token)`,
+  `clearAllSubscriptions` — required by hooks/tests.
+- `subscribeOnce` — cheap, commonly used, documented upstream.
+- `unsubscribe(handler)` (by function reference) — cheap, common.
+- Symbol tokens — the hook types accept `symbol` and a test verifies it.
+
+**ADD (the "better API"):**
+- `createPubSub<EventMap>()` typed factory.
+- `on(token, handler, { signal })` → returns unsubscribe fn; `AbortSignal`
+  teardown (one `AbortController.abort()` can cancel many subscriptions).
+
+**DROP (unused internally, document in CHANGELOG):**
+- Hierarchical/namespaced dotted-topic propagation (`a.b.c` → `a.b` → `a`).
+  *Medium-risk drop* (pubsub-js documents it prominently). **Decision: drop**;
+  call it out loudly in the migration notes. Re-add later only if requested.
+- `publishSync` (the "here be dragons" sync path), `subscribeAll`/`*` wildcard,
+  `clearSubscriptions(topic)`, `countSubscriptions`, `getSubscriptions`,
+  `immediateExceptions`, `unsubscribe(topicString)` — niche/diagnostic.
+
+## Behaviors that MUST match (verified by the contract tests)
+
+1. **Async delivery** via `setTimeout(0)` — handler not called during `publish()`.
+2. **`subscribe` returns a truthy string token**; `unsubscribe(token)` removes it.
+3. **`publish` returns `false` when there are no subscribers** (drives `lastPublish`).
+4. **Per-subscriber error isolation** — a throwing handler must not abort delivery
+   to the others (pubsub-js re-throws async; we do the same).
+5. **Snapshot subscribers before delivery** — subscribing/unsubscribing during a
+   delivery must not corrupt the current dispatch.
+
+## Decision: symbol handling — IDENTITY, not stringification
+
+pubsub-js does `message.toString()`, so two *distinct* `Symbol('x')` collide
+(both become `"Symbol(x)"`). **Decision: key subscriptions by the actual
+`string | symbol` value (identity).** This removes a real footgun and is
+strictly better; the existing Symbol test (same instance for sub+publish) still
+passes. It is a **behavior difference** from pubsub-js for the (pathological)
+same-description-different-instance case — documented as an intentional
+improvement. *Flagged for review/maintainer in 07.*
+
+## Implementation sketch
+
+```ts
+const channels = new Map<string | symbol, Map<Token, Listener>>()
+let uid = 0
+
+function subscribe(token, handler) {
+  const id = `uid_${uid++}`
+  let m = channels.get(token)
+  if (!m) channels.set(token, (m = new Map()))
+  m.set(id, handler)
+  return id
+}
+function unsubscribe(value) {
+  let removed = false
+  for (const m of channels.values()) {
+    if (typeof value === 'function') {
+      for (const [id, fn] of m) if (fn === value) { m.delete(id); removed = true }
+    } else if (m.delete(value)) removed = true
+  }
+  return removed
+}
+function publish(token, data) {
+  const m = channels.get(token)
+  if (!m || m.size === 0) return false
+  const snapshot = [...m.values()]
+  setTimeout(() => {
+    for (const fn of snapshot) {
+      try { fn(String(token), data) } catch (err) { setTimeout(() => { throw err }, 0) }
+    }
+  }, 0)
+  return true
+}
+```
+
+(`subscribeOnce`, `on`, `clearAllSubscriptions` build on these. Final code lives
+behind the contract + parity tests.)

--- a/docs/migration-v2/02-react-improvements.md
+++ b/docs/migration-v2/02-react-improvements.md
@@ -6,33 +6,28 @@ gating approach. None of these change the hooks' public API or behavior.
 
 ## Ship in v2.0.0 (React 17+, no gating)
 
-### R6 — Latest-handler ref: `useEffect` → isomorphic `useLayoutEffect`
-`useSubscribe` keeps the handler fresh with a dep-less `useEffect`:
+### R6 — ~~`useEffect` → isomorphic `useLayoutEffect`~~ **DROPPED** (see 08-V16)
+Adversarial review showed this is cargo-cult: with `setTimeout(0)` delivery the
+render→effect stale-handler window is **unreachable** (the existing "handler
+changes" test proves the current `useEffect` is correct), and `useLayoutEffect`
+adds SSR/layout cost for no observable gain. **Decision: leave the handler-ref
+`useEffect` as-is in v2.** The render-time ref write
+(`handlerRef.current = handler` during render) and `useEffectEvent` (19.2) are
+recorded in 06 as the preferred options *if* we ever touch this hook.
+
+### R3 — Memoize the hooks' return objects **(now v2.0.0 core — see 08-V3)**
+`useSubscribe` returns a fresh `{ unsubscribe, resubscribe }` each render;
+`usePublish` returns a fresh `{ lastPublish, publish }`. The inner fns are already
+`useCallback`-stable, but the **object identity** changes every render. With
+`eslint-plugin-react-hooks/exhaustive-deps` (ubiquitous), a consumer who captures
+the whole return and puts it in a dep array gets an **infinite effect loop** —
+"document destructuring" doesn't prevent that.
 ```ts
-useEffect(() => { handlerRef.current = handler })
+return useMemo(() => ({ unsubscribe, resubscribe }), [unsubscribe, resubscribe])
 ```
-`useEffect` runs *after paint*, leaving a small window where `handlerRef.current`
-is stale. Switching to `useLayoutEffect` (guarded for SSR) shrinks that window to
-before paint — a pure internal correctness gain, works on all supported React.
-
-```ts
-const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
-
-useIsomorphicLayoutEffect(() => { handlerRef.current = handler })
-```
-- Min React: 17. Gating: none (SSR handled by the isomorphic guard).
-- Risk: low. No test changes (tests advance timers past 0 before asserting).
-- **Decision: include in v2.0.0 core.**
-
-### R3 — Referential stability of returned objects (document; optional `useMemo`)
-`useSubscribe` returns a fresh `{ unsubscribe, resubscribe }` object each render
-(both fns are already `useCallback`-stable); `usePublish` returns a fresh
-`{ lastPublish, publish }`. Only matters if a consumer passes the whole object to
-a `memo` child / effect dep.
-- **Decision:** document "destructure the return value" in the README. Add
-  `useMemo` on the returned object only if a real re-render cost is shown
-  (deferred; React Compiler handles it automatically for adopters).
+- Min React: 16.8. Gating: none. Behavior-neutral (same values, stable identity).
+- **Decision: include in v2.0.0 core** (was "document only" — upgraded by review).
+  Also document destructuring in the README as a complement.
 
 ## Progressive enhancement (React 19.2+ lane) — opt-in, additive
 
@@ -71,8 +66,11 @@ about `use`).
 
 | Item | Min React | In v2.0.0? | Gating | API change |
 | --- | --- | --- | --- | --- |
-| R6 isomorphic layout effect | 17 | **Yes (core)** | none | none |
-| R3 stable return (doc) | any | Yes (docs) | none | none |
-| R1 `useEffectEvent` | 19.2 | maybe (sub-path) | sub-path export | none |
+| R3 `useMemo` the returns | 16.8 | **Yes (core)** | none | none |
+| R6 isomorphic layout effect | 17 | **No — dropped (08-V16)** | — | — |
+| R1 `useEffectEvent` | 19.2 | maybe (sub-path, Q3) | sub-path export | none |
 | USES | 18 | no | — | — |
 | `use` | 19 | no | — | — |
+
+> v2 core's only React change is **R3** (memoize the return objects). The
+> handler-ref effect is left untouched.

--- a/docs/migration-v2/02-react-improvements.md
+++ b/docs/migration-v2/02-react-improvements.md
@@ -1,0 +1,78 @@
+# 02 — React-side improvements & version-gating
+
+Floor is React `>=17`. Rule: **newer-React users may benefit; older-React users
+must not break.** Each item below is tagged with its min React version and a
+gating approach. None of these change the hooks' public API or behavior.
+
+## Ship in v2.0.0 (React 17+, no gating)
+
+### R6 — Latest-handler ref: `useEffect` → isomorphic `useLayoutEffect`
+`useSubscribe` keeps the handler fresh with a dep-less `useEffect`:
+```ts
+useEffect(() => { handlerRef.current = handler })
+```
+`useEffect` runs *after paint*, leaving a small window where `handlerRef.current`
+is stale. Switching to `useLayoutEffect` (guarded for SSR) shrinks that window to
+before paint — a pure internal correctness gain, works on all supported React.
+
+```ts
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+useIsomorphicLayoutEffect(() => { handlerRef.current = handler })
+```
+- Min React: 17. Gating: none (SSR handled by the isomorphic guard).
+- Risk: low. No test changes (tests advance timers past 0 before asserting).
+- **Decision: include in v2.0.0 core.**
+
+### R3 — Referential stability of returned objects (document; optional `useMemo`)
+`useSubscribe` returns a fresh `{ unsubscribe, resubscribe }` object each render
+(both fns are already `useCallback`-stable); `usePublish` returns a fresh
+`{ lastPublish, publish }`. Only matters if a consumer passes the whole object to
+a `memo` child / effect dep.
+- **Decision:** document "destructure the return value" in the README. Add
+  `useMemo` on the returned object only if a real re-render cost is shown
+  (deferred; React Compiler handles it automatically for adopters).
+
+## Progressive enhancement (React 19.2+ lane) — opt-in, additive
+
+### R1 — `useEffectEvent` for `useSubscribe` (replaces the ref+effect entirely)
+`useEffectEvent` (stable in React 19.2, Oct 2025) is the canonical fix for the
+"latest ref" pattern: a stable function identity that always calls the latest
+`handler`, no ref + effect needed.
+```ts
+const internalHandler = useEffectEvent((msg, data) => handler(msg as TokenType, data))
+```
+- Min React: **19.2**. Cannot be conditionally called (Rules of Hooks), so gate
+  via a **separate sub-path export** rather than a runtime `if`:
+  - `use-pubsub-js/react19/useSubscribe` (and maybe `/usePublish`) — a parallel
+    entry using `useEffectEvent`; the default entry keeps the R6 implementation.
+  - Zero overhead/zero risk for existing users; React 19.2 users opt in.
+- **Decision:** **save as a ready-to-build progressive-enhancement** (see
+  06-ideas-backlog). *Open question for maintainer:* ship the `react19` sub-path
+  *in* v2.0.0 (additive, safe) or in a later v2.x? (07, Q3)
+
+## Considered and rejected (recorded so we don't re-litigate)
+
+### USES — `useSyncExternalStore`: **not a fit**
+USES is for **readable snapshot state** with tearing protection. `useSubscribe`
+delivers **push events** with no "current value" to snapshot. Forcing USES would
+require the bus to store last-value state it doesn't need and would add a render
+cycle per message. Revisit **only** if the bus ever grows a
+BehaviorSubject/replay-last-value mode (then USES becomes natural + needs
+`getServerSnapshot` for SSR). Min React: 18. **Decision: skip.**
+
+### React 19 `use`: **not applicable**
+`use` reads Promises/Context for Suspense. Neither hook involves suspendable
+data. **Decision: skip** (recorded because the maintainer specifically asked
+about `use`).
+
+## Summary
+
+| Item | Min React | In v2.0.0? | Gating | API change |
+| --- | --- | --- | --- | --- |
+| R6 isomorphic layout effect | 17 | **Yes (core)** | none | none |
+| R3 stable return (doc) | any | Yes (docs) | none | none |
+| R1 `useEffectEvent` | 19.2 | maybe (sub-path) | sub-path export | none |
+| USES | 18 | no | — | — |
+| `use` | 19 | no | — | — |

--- a/docs/migration-v2/03-testing-strategy.md
+++ b/docs/migration-v2/03-testing-strategy.md
@@ -1,0 +1,91 @@
+# 03 — Testing strategy
+
+The 41-test suite already includes a pub/sub **contract** suite (async delivery,
+payload-by-reference, multi-subscriber isolation, Symbol tokens, cross-hook
+integration). That's the backbone for a safe swap, but it has gaps. This plan
+closes them, adds in-isolation module tests, and adds a **differential/parity**
+test that mechanically proves the new module behaves like pubsub-js.
+
+## A. Repoint the test oracle (required)
+
+Today the hook specs `import PubSub from 'pubsub-js'` and use it as the oracle
+(subscribe to observe, publish to drive). After the swap, the hooks import the
+**internal** module; the specs must import the **same** singleton
+(`../pubsub`), or tests will exercise a different instance and silently pass on
+stale behavior. This is a required, mechanical change in all spec files.
+
+## B. Contract gaps to close (MUST-HAVE — protect the swap)
+
+Add these (in `useSubscribe.spec.ts` and/or the new module spec):
+1. **Delivery order** across N subscribers (assert insertion order via a shared counter).
+2. **Error isolation** — handler A throws, handler B still receives.
+3. **Unsubscribe-during-delivery** — a handler unsubscribing (itself/another) mid-dispatch doesn't skip others in the current dispatch (snapshot semantics).
+4. **Re-entrancy** — a handler that `publish()`es another token doesn't deadlock/lose messages.
+5. **`clearAllSubscriptions()` semantics** — after it, publishes return `false` (and it exists — the `afterEach` depends on it).
+6. **Symbol identity** — two different `Symbol('x')` (same description) must NOT cross-deliver (verifies identity-keying, per 01 decision). This is the test that pins the intentional difference from pubsub-js.
+
+NICE-TO-HAVE: large fan-out (20 subscribers each once); repeated subscribe/
+unsubscribe cycles leave clean state.
+
+## C. New in-isolation module tests (MUST-HAVE)
+
+`src/pubsub/pubsub.spec.ts` — test the module directly (not through hooks) so a
+failure points at the module:
+- subscribe→token; unsubscribe(token) and unsubscribe(handler); publish return
+  value (true/false); async delivery; `(token, data)` arg order; payload by
+  reference; fan-out + order; error isolation; re-entrancy; symbol identity;
+  `subscribeOnce` fires once; `on()` returns a working unsubscribe fn;
+  `on(..., { signal })` unsubscribes on `abort()`; `clearAllSubscriptions()`.
+
+## D. Differential / parity test (MUST-HAVE during migration)
+
+`src/pubsub/parity.spec.ts` — parameterize the same scenarios over **both**
+`pubsub-js` (reference) and the internal module, asserting identical observable
+output for the **shared** surface (publish return, async delivery, by-reference,
+fan-out, unsubscribe isolation, error isolation). Keep `pubsub-js` as a
+**devDependency** for this only.
+
+- Exclude the intentionally-divergent cases (symbol identity vs stringify;
+  dropped hierarchical topics) from parity, or assert the *documented*
+  difference explicitly.
+- Both buses are separate imports → independent state; reset in `afterEach`.
+- Delivery mechanism must match (`setTimeout(0)`), or the fake-timer flush
+  differs. The module MUST use `setTimeout`, not microtasks.
+- **Lifecycle decision:** parity is a *migration artifact*. Keep it (and the
+  `pubsub-js` devDep) on the v2 branch and through the v2 PR's CI; **remove both
+  before tagging v2.0.0** so the released package has zero deps and no stray
+  reference dep. *(Flagged in 07, Q4: keep vs remove.)*
+
+## E. Smoke tests (MUST-HAVE)
+
+`e2e/test.cjs` + `e2e/test.mjs` currently only assert exports are defined.
+Extend with a runtime check that needs no React/jsdom:
+`PubSub.subscribe(t, h)` → `PubSub.publish(t, data)` → flush one tick → assert
+`h` called with `(t, data)`; assert `clearAllSubscriptions` exists. If `./pubsub`
+becomes a public subpath, smoke-test that entry too (CJS + ESM). Runs via the
+existing `pnpm test:e2e` in `e2e-test.yml` — no new job.
+
+## F. CI
+
+- **Coverage thresholds** in `vitest.config.ts` (branches/functions/lines/
+  statements: 100) so the current 100% can't silently regress. Vitest exits
+  non-zero on miss — no new step. (Note: `src/index.ts` is already coverage-
+  excluded; ensure new entry/barrel files are excluded consistently.)
+- Parity + new specs run automatically (vitest picks up `*.spec.ts`).
+- Optional: a distinct `parity` job for visibility / clean removal later
+  (NICE-TO-HAVE).
+
+## G. Determinism / flakiness
+
+- Module MUST deliver via `setTimeout(0)` so `vi.advanceTimersByTime(0)` flushes it.
+- Standardize new spec files on `beforeEach(vi.useFakeTimers)` /
+  `afterEach(vi.useRealTimers)` to avoid timer-state leakage across files.
+- Timer advances that cause React state updates stay inside `act()`; direct
+  bus/parity tests (no React) must NOT use `act()`.
+
+## Definition of done (tests)
+
+- All contract gaps (B) + module tests (C) green; parity (D) green for the shared
+  surface; smoke (E) green in CI; coverage thresholds (F) enforced; suite
+  deterministic (G). Net: the swap cannot change observable behavior without a
+  red test.

--- a/docs/migration-v2/04-packaging-dx.md
+++ b/docs/migration-v2/04-packaging-dx.md
@@ -1,0 +1,104 @@
+# 04 — Packaging & DX
+
+## Dependency removal (the headline)
+
+- Remove `pubsub-js` from `dependencies` (and drop the now-empty `dependencies`
+  key) and `@types/pubsub-js` from `devDependencies`.
+- Result: **zero runtime dependencies.** `sideEffects: false` stays correct
+  (it describes this package's exports, not the singleton internals).
+- `pubsub-js` is `unbundle`'d today (shipped as an external the consumer
+  installs), so the win is a narrower install graph for consumers, plus full
+  ownership of behavior and types.
+
+## Exports map
+
+Add a dedicated subpath for the bus so it can be used outside React (test setup,
+workers, non-React code) without pulling React types:
+
+```jsonc
+"exports": {
+  ".":                  { /* unchanged */ },
+  "./pubsub": {
+    "import":  { "types": "./dist/pubsub/index.d.ts",  "default": "./dist/pubsub/index.js" },
+    "require": { "types": "./dist/pubsub/index.d.cts", "default": "./dist/pubsub/index.cjs" }
+  },
+  "./hooks/usePublish":  { /* unchanged */ },
+  "./hooks/useSubscribe":{ /* unchanged */ },
+  "./utils/debounce":    { /* unchanged */ },
+  "./package.json": "./package.json"
+}
+```
+
+- Keep `types` before `default` in each condition (attw/publint requirement —
+  already correct in the repo).
+- Mirror the new subpath in `typesVersions` (publint warns otherwise):
+  `"pubsub": ["./dist/pubsub/index.d.ts"]`.
+- If R1's React 19 lane ships (02), add `./react19/useSubscribe` similarly.
+- `unbundle: true` + the `src/**/*.ts` glob means `src/pubsub/index.ts` →
+  `dist/pubsub/index.{js,cjs,d.ts,d.cts}` automatically. **No tsdown/tsconfig
+  change required.** (`isolatedModules` is fine — the file exports.)
+
+## Types
+
+- Replace `type Message = any` → `unknown` in `useSubscribe`; drop the
+  `biome-ignore noExplicitAny`. Handlers must narrow — this is a **breaking type
+  change** (bundled into v2; see also the deferred semver items in 07).
+- The new module ships real types: `PubSubBus`, `TypedPubSub<E>`, `EventMap`,
+  `Listener<T>`, `createPubSub`.
+- Validate with `attw --pack` (all entries green across node10/node16/bundler —
+  keep the `typesVersions` node10 shim) and `publint` (all good).
+
+## Build
+
+No `tsdown.config.ts` / `tsconfig.json` change needed for the new module file.
+Confirm after adding it that `pnpm build` emits the `dist/pubsub/*` quartet and
+attw/publint stay green.
+
+## Deferred semver-major cleanups to bundle into v2 (maintainer chose "single big v2.0.0")
+
+- **#4** `debounce.ts`: drop `@ts-nocheck`, narrow `T extends Function` →
+  `T extends (...args: any[]) => any`, type `args` as `any[]`. Re-enable the
+  Biome rules disabled for that file where possible.
+- **#5** interface naming: unify `IUsePublishResponse`/`IUsePublishParams` →
+  `UsePublishResponse`/`UsePublishParams` (match `UseSubscription*`). Breaking
+  type rename.
+- **#8** remove the undocumented `export default { ... }` from `src/index.ts`
+  (named exports only). Also clears the `MIXED_EXPORTS` build warning.
+- **#7** `debounceMs: number | string`: **keep as-is** (string coercion is
+  documented and used). *Decision: do NOT narrow.* (See 07.)
+
+## Consumer migration guide (draft CHANGELOG bullets for v2.0.0)
+
+**Breaking:**
+- `pubsub-js` is no longer a dependency. `PubSub` is now the library's own
+  internal bus. **If you previously also used `pubsub-js` directly elsewhere in
+  your app, you were sharing one global singleton with this package; in v2 the
+  internal bus is a separate instance — messages won't cross.** Import `PubSub`
+  exclusively from `use-pubsub-js` for a single shared bus.
+- **Dropped pubsub-js features**: hierarchical/namespaced dotted topics,
+  `publishSync`, `subscribeAll`/`*` wildcard, `clearSubscriptions(topic)`,
+  `countSubscriptions`, `getSubscriptions`, `immediateExceptions`,
+  `unsubscribe(topicString)`. (Kept: `publish`, `subscribe`, `subscribeOnce`,
+  `unsubscribe(token|handler)`, `clearAllSubscriptions`.)
+- **Symbol tokens are matched by identity**, not by string form. Two different
+  `Symbol('x')` no longer collide (this was a pubsub-js quirk).
+- **`message` payload type tightened `any` → `unknown`** — add a guard/cast in
+  typed handlers.
+- Removed the **default export**; use named imports.
+- Type renames: `IUsePublish*` → `UsePublish*`.
+
+**Additive:**
+- `import { PubSub } from 'use-pubsub-js/pubsub'` — use the bus directly.
+- `createPubSub<EventMap>()` — fully-typed channels.
+- `on(token, handler, { signal })` — returns an unsubscribe fn; `AbortSignal`
+  teardown.
+- Zero runtime dependencies.
+
+## Metadata
+
+- `version: 2.0.0`.
+- Update `description` (currently implies "wrapper of pubsub-js") to e.g.
+  "Lightweight, dependency-free React hooks + pub/sub bus".
+- README: fix the "wrapper of pubsub-js" subtitle and the "see pubsub-js docs"
+  delegation; document the actual supported `PubSub` surface + `createPubSub`.
+  Keep keywords; optionally add `zero-dependencies`.

--- a/docs/migration-v2/05-milestones.md
+++ b/docs/migration-v2/05-milestones.md
@@ -1,0 +1,77 @@
+# 05 — Milestones (execution order)
+
+One **v2.0.0**, executed as a sequence of small PRs into `main` (main runs ahead
+of the published 1.3.3 until we tag v2). Each PR follows the project's standard
+gate: local build + test/coverage + lint + e2e green → adversarial subagent
+review → independently verify findings → CI green → squash-merge. The ordering
+front-loads the **safety net** so the actual swap is verifiable.
+
+> Tests-first is deliberate: M0 lands the contract-gap tests *against the current
+> pubsub-js backend* (they pass now), so when M2 swaps the backend any divergence
+> turns a test red instead of shipping silently.
+
+## M0 — Contract safety net (against current pubsub-js)
+Add the MUST-HAVE contract-gap tests from 03-§B (delivery order, error isolation,
+unsubscribe-during-delivery, re-entrancy, `clearAllSubscriptions`, symbol
+behavior) to the existing suite. They must pass against pubsub-js today.
+**Gate:** suite green incl. new tests; no source change.
+*Note:* the symbol-identity test (03-§B.6) asserts the **new** intended behavior,
+which differs from pubsub-js — write it in M1/M2 against the new module, not here.
+
+## M1 — Build the internal module (not wired into hooks yet)
+- `src/pubsub/index.ts`: `PubSub`, `createPubSub`, `on`, `subscribeOnce`,
+  `unsubscribe(token|handler)`, `clearAllSubscriptions` (per 01).
+- `src/pubsub/pubsub.spec.ts`: in-isolation unit tests (03-§C).
+- `src/pubsub/parity.spec.ts`: differential test vs pubsub-js (03-§D); keep
+  `pubsub-js` as devDep.
+**Gate:** module unit tests + parity green; build/attw/publint green; hooks/
+public API untouched.
+
+## M2 — Swap the hooks + index to the internal module
+- `useSubscribe`/`usePublish`/`src/index.ts`: import from `../pubsub`; repoint the
+  spec oracles (03-§A). Remove `pubsub-js` from `dependencies` (keep as devDep
+  for parity until M6).
+- `Message = any` → `unknown` in `useSubscribe`.
+**Gate:** full suite (incl. contract + integration) green; parity green; e2e
+green; behavior identical to 1.3.3 except the documented intentional differences.
+**This is the riskiest PR — most scrutiny in review.**
+
+## M3 — React correctness improvement (R6) + return-stability docs
+- `useSubscribe`: dep-less `useEffect` → `useIsomorphicLayoutEffect` (02-§R6).
+- README: document destructuring the return value (02-§R3).
+**Gate:** suite green; no public API change. *(May be folded into M2 if small.)*
+
+## M4 — Semver-major cleanups (bundled per "single big v2.0.0")
+- `debounce.ts`: drop `@ts-nocheck`, narrow the generic, type `args` (#4).
+- Rename `IUsePublish*` → `UsePublish*` (#5).
+- Remove the `export default { ... }` barrel (#8); clears `MIXED_EXPORTS`.
+- Keep `debounceMs: number | string` (decided — not narrowing, #7).
+**Gate:** suite green; emitted `.d.ts` reviewed; attw/publint green.
+
+## M5 — Packaging: `./pubsub` subpath + types
+- Add `./pubsub` export + `typesVersions` entry; update description/keywords;
+  drop the empty `dependencies` key and `@types/pubsub-js`.
+**Gate:** attw `--pack` all-green, publint clean, frozen install (root+example),
+e2e smoke (incl. the new subpath, CJS+ESM) green.
+
+## M6 — Docs, migration notes, remove migration scaffolding
+- README rewrite (drop "wrapper of pubsub-js"; document `PubSub` surface +
+  `createPubSub` + `on`); CHANGELOG migration section (04).
+- **Remove `parity.spec.ts` and the `pubsub-js` devDep** so the released package
+  is truly dependency-free. Add coverage thresholds to `vitest.config.ts` (03-§F).
+**Gate:** suite green without pubsub-js present; audit clean; zero deps confirmed.
+
+## M7 — Release v2.0.0 (maintainer-triggered)
+- Confirm CHANGELOG reads as a major; trigger the OIDC release workflow.
+  **I do not trigger releases.**
+- *Optional, if chosen (07-Q3):* ship the `react19` sub-path (R1) — either within
+  M3/M5 or as a fast-follow v2.1.
+
+## Cross-cutting gates (every PR)
+build · test+coverage · lint (ultracite) · e2e · `pnpm audit` clean · adversarial
+review with findings independently verified · CI green before squash-merge.
+
+## Rollback posture
+Each milestone is independently revertable. The risky swap (M2) is guarded by the
+contract suite (M0) + parity (M1); if parity/contedract diverges unexpectedly, fix
+the module before proceeding — never weaken a test.

--- a/docs/migration-v2/06-ideas-backlog.md
+++ b/docs/migration-v2/06-ideas-backlog.md
@@ -1,0 +1,53 @@
+# 06 — Ideas backlog (save for later / progressive enhancement)
+
+Ideas worth keeping but not committing to v2.0.0 core. Each is tagged with the
+version it depends on and how to ship it without breaking older users (the
+maintainer's rule: *newer can use, older don't break*).
+
+## React 19.2+ — `useEffectEvent` lane (R1)
+Replace the latest-ref pattern in `useSubscribe` with `useEffectEvent` (stable
+19.2). Ship as a **separate sub-path export** `use-pubsub-js/react19/useSubscribe`
+(can't gate with a runtime `if` — Rules of Hooks). Default entry keeps the
+React-17-safe implementation. Zero risk to existing users.
+- Gating: sub-path export. Min React 19.2.
+- Could land *in* v2.0.0 (additive) — see 07-Q3.
+
+## Typed hooks via an optional `Events` generic
+Give `useSubscribe`/`usePublish` an additive second generic
+`Events extends EventMap = Record<string|symbol, unknown>` so callers can get
+fully-typed handlers/payloads while existing call sites (one generic or none)
+keep compiling. Pairs with `createPubSub`. Defaulting requires only TS 2.3+.
+- Gating: none (purely additive types). Could be in v2 if review wants it;
+  otherwise a minor v2.x.
+
+## `useSyncExternalStore` — only if the bus gains readable state
+Not applicable to a pure event bus (see 02). If a future "replay last value" /
+BehaviorSubject mode is added, USES becomes the right integration (with
+`getServerSnapshot` for SSR). Min React 18 (shim for 16+).
+
+## React Compiler note
+React Compiler v1.0 (Oct 2025) auto-memoizes; consumers who adopt it get the
+return-object stability (02-§R3) for free. Nothing for us to do; mention in docs.
+
+## Optional bus features (add only on request)
+- `publishSync` — synchronous delivery (pubsub-js's "here be dragons"). Easy to
+  add as a separate method; omitted by default to keep the surface lean & the
+  async contract clear.
+- `*` wildcard / `subscribeAll` — global listener (logging/devtools). Conflicts
+  cleanly-typed event maps; omit unless needed.
+- `once` at the module level — currently expressible via
+  `on(t, h, { signal })` + `abort()` after first delivery, and `subscribeOnce`
+  covers the common case.
+- hierarchical/namespaced topics — the one notable dropped pubsub-js feature; if
+  consumers ask, re-introduce behind an opt-in (e.g. a `createPubSub({ hierarchical: true })`).
+
+## Performance micro-ideas (measure before doing)
+- Avoid the delivery-time array snapshot allocation when a channel has a single
+  subscriber (fast path).
+- Consider a `Set`-backed channel if unsubscribe-by-handler becomes hot (trade
+  off vs insertion-order guarantees).
+These are negligible at this library's scale — only act with a benchmark.
+
+## Tooling
+- Optional `parity` CI job kept around (behind a flag) for any future bus rewrite.
+- Re-evaluate `noBarrelFile`/exports lint once the default export is removed.

--- a/docs/migration-v2/07-decisions-and-risks.md
+++ b/docs/migration-v2/07-decisions-and-risks.md
@@ -28,9 +28,19 @@
 
 ## Open questions for the maintainer (please confirm at review)
 
-- **Q1 — Drop hierarchical/dotted topics?** It's the one prominent pubsub-js
-  feature being removed. Default plan: **drop + document**. OK, or keep it
-  (behind an opt-in)?
+- **Q1 — Hierarchical/dotted topics?** (sharpened by review, 08-V18) Dropping is
+  a *silent* runtime break for consumers who used dotted topics. Pick: **(a)**
+  drop + loud CHANGELOG (lean, default); **(b)** ship an opt-in
+  `createPubSub({ hierarchical: true })` in v2.0.0 (small ancestor-walk on
+  publish) so migrators have a path.
+- **Q7 — `createPubSub` is a separate bus from the hooks (08-V17).** Pick: **(a)**
+  defer `createPubSub` to v2.1, ship v2.0.0 as a clean dep-swap + lean `PubSub` +
+  `on` only; **(b)** ship `createPubSub` *and* add an optional `bus` param to the
+  hooks so a typed bus integrates end-to-end (additive hook-API change); **(c)**
+  ship `createPubSub` standalone with explicit "separate bus" docs.
+- **Q8 — Symbol token delivery (08-V2):** confirm the intentional improvement —
+  handlers now receive the **original** `symbol` token (not its string form).
+  This differs from today's behavior; OK?
 - **Q2 — Symbol identity vs stringify (D3)?** Default: **identity** (better).
   Confirm you're fine with the (pathological) behavior difference vs pubsub-js.
 - **Q3 — Ship the React 19.2 `useEffectEvent` sub-path (R1) inside v2.0.0**

--- a/docs/migration-v2/07-decisions-and-risks.md
+++ b/docs/migration-v2/07-decisions-and-risks.md
@@ -1,0 +1,69 @@
+# 07 — Decision log, open questions, risks
+
+## Decision log (decided in this plan; challengeable in review)
+
+- **D1 — API shape:** ship a lean compatible `PubSub` singleton **and** a typed
+  `createPubSub<EventMap>()` factory **and** an `on(token, handler, { signal })`
+  sugar. Best of "lean" + "better". (01)
+- **D2 — keep:** `publish`(async), `subscribe`(→string token), `unsubscribe(token
+  |handler)`, `subscribeOnce`, `clearAllSubscriptions`. **drop:** hierarchical
+  topics, `publishSync`, wildcard/`subscribeAll`, `clearSubscriptions(topic)`,
+  `countSubscriptions`, `getSubscriptions`, `immediateExceptions`,
+  `unsubscribe(topicString)`. (01)
+- **D3 — symbol tokens: identity-keyed**, not stringified. Fixes a pubsub-js
+  footgun; intentional behavior difference. (01)
+- **D4 — delivery stays async `setTimeout(0)`**; per-subscriber error isolation;
+  subscriber-snapshot before dispatch. (01/03)
+- **D5 — `subscribe` returns an opaque STRING token** (drop-in for current hooks
+  & pubsub-js consumers); modern unsubscribe-fn available via `on`. (01)
+- **D6 — React:** R6 (isomorphic layout effect) in core; R1 (`useEffectEvent`)
+  as an opt-in `react19` sub-path; USES & `use` rejected (recorded). (02)
+- **D7 — tests:** close contract gaps first (M0), in-isolation module tests,
+  differential parity vs pubsub-js (temporary), runtime smoke, 100% coverage
+  thresholds. (03)
+- **D8 — bundle semver-major cleanups into v2:** `Message any→unknown`, debounce
+  typing (#4), interface rename `IUsePublish*`→`UsePublish*` (#5), remove default
+  export (#8). **Keep `debounceMs: number|string`** (do NOT narrow, #7). (04)
+- **D9 — single v2.0.0** (maintainer), executed as ordered PRs (05).
+
+## Open questions for the maintainer (please confirm at review)
+
+- **Q1 — Drop hierarchical/dotted topics?** It's the one prominent pubsub-js
+  feature being removed. Default plan: **drop + document**. OK, or keep it
+  (behind an opt-in)?
+- **Q2 — Symbol identity vs stringify (D3)?** Default: **identity** (better).
+  Confirm you're fine with the (pathological) behavior difference vs pubsub-js.
+- **Q3 — Ship the React 19.2 `useEffectEvent` sub-path (R1) inside v2.0.0**
+  (additive, safe) or defer to v2.1?
+- **Q4 — Parity test + `pubsub-js` devDep:** default plan removes both before
+  tagging v2.0.0 (truly zero-dep). Keep them around instead (for future bus
+  changes)?
+- **Q5 — Add the optional typed `Events` generic to the hooks in v2** (additive),
+  or leave hooks untyped-payload and only `createPubSub` typed? (06)
+- **Q6 — `subscribeOnce` / `unsubscribe(handler)`:** keep for compat (default),
+  or go fully minimal and drop them too?
+
+## Risks & mitigations
+
+- **Silent behavior drift on swap (highest).** Mitigation: contract suite landed
+  first (M0) against pubsub-js + differential parity (M1) + repoint oracle to the
+  real singleton (so tests can't pass on a stale instance).
+- **Separate-bus-instance breakage.** Consumers who used `pubsub-js` directly
+  *and* our re-exported `PubSub` shared one global singleton; v2's bus is separate
+  → messages won't cross. Mitigation: loud CHANGELOG note; recommend importing
+  `PubSub` only from `use-pubsub-js`.
+- **Dropping hierarchical topics** silently breaks consumers who adopted dotted
+  topics from the upstream docs (their parent-topic subscribers stop receiving).
+  Mitigation: explicit CHANGELOG + README; Q1; opt-in re-add path documented (06).
+- **`any → unknown`** breaks handlers that used the payload untyped. Mitigation:
+  it's a major; documented; trivial consumer fix (cast/guard).
+- **Fake-timer/microtask mismatch.** If the module used microtasks, every
+  fake-timer test breaks. Mitigation: enforce `setTimeout(0)` (D4) + parity.
+- **Removing default export** breaks `import x from 'use-pubsub-js'`. Mitigation:
+  major + documented; it was undocumented.
+- **attw/publint regressions** from the new subpath. Mitigation: validate in M5;
+  `typesVersions` mirrors the subpath.
+
+## Out of scope for v2
+USES integration, wildcard/`once`-at-module, hierarchical topics, performance
+micro-opts — all in 06, to be picked up on demand.

--- a/docs/migration-v2/08-review-verdicts.md
+++ b/docs/migration-v2/08-review-verdicts.md
@@ -1,0 +1,144 @@
+# 08 — Adversarial review verdicts & plan amendments
+
+Three adversarial reviewers (API/architecture, testing/safety, React correctness)
+challenged the plan. Each challenge below has my **verdict** (I adjudicated;
+some I verified directly against the code). **This doc is authoritative where it
+conflicts with 01–07** — accepted items are the plan of record.
+
+## Accepted — BLOCKERS (verified)
+
+### V1 — `example/` app breaks silently in v2 (was entirely missed)
+Verified: `example/src/service/publish.ts` does `import PubSub from 'pubsub-js'`,
+and `example/package.json` does **not** list `pubsub-js` — it only resolves today
+via hoisting from the root's runtime dep. Removing the dep in v2 breaks the
+example, and CI installs the example but never **builds** it.
+- **Amendment:** in **M2**, change that import to `import { PubSub } from 'use-pubsub-js'`
+  (use the library's own bus). Add `pnpm --prefix ./example build` as a real CI
+  gate (it currently isn't built anywhere). Drop the example's now-unneeded
+  `@types/pubsub-js`.
+
+### V2 — `String(token)` delivery contradicts identity-keying & the typed API
+Verified: the symbol test only asserts `calls[0][1]` (data), and the hook does
+`handlerRef.current(msg as TokenType, data)` on a **stringified** token — so a
+`symbol` subscriber's handler receives `"Symbol(x)"` today, and `as TokenType`
+is a type-lie. My 01 sketch (`fn(String(token), data)`) carried this forward and
+would make the new `TypedPubSub<E>` handler types contradict runtime.
+- **Amendment:** deliver the **original** token: `fn(token, data)`; `Listener<T>`
+  becomes `(token: string | symbol, data: T) => void`. Add assertions on
+  `calls[0][0]` for both a string and a symbol token. This makes the hook's
+  `as TokenType` truthful. It is an intentional, documented behavior improvement
+  (handlers now receive the real symbol, not its string form).
+
+### V3 — Memoize the hooks' return objects (don't just "document destructuring")
+The returned `{ unsubscribe, resubscribe }` / `{ lastPublish, publish }` are new
+objects each render. `eslint-plugin-react-hooks/exhaustive-deps` pushes consumers
+to put the whole object in a dep array → infinite `useEffect` loop. Documentation
+won't prevent it.
+- **Amendment:** `useMemo` both hook return objects in **v2 core** (the inner
+  fns are already `useCallback`-stable, so it's behavior-neutral and cheap).
+  Supersedes 02-§R3's "document only".
+
+### V4 — e2e smoke is behavioral-zero and must be written early
+Current e2e only asserts exports are defined. The plan assumed the runtime
+extension; it isn't written, and `ci.yml` doesn't run e2e at all (only
+`e2e-test.yml` on PRs).
+- **Amendment:** write the runtime smoke (subscribe→publish→`await` ~10ms→assert
+  handler fired with `(token, data)`; assert `createPubSub` exists and the
+  default export is `undefined`) in **M1/M2**, CJS+ESM, with real-timer-robust
+  delay. Not deferred to M5/M6.
+
+## Accepted — STRONG
+
+- **V5 (testing#4): coverage thresholds → M1, not M6.** Enforce 100% on
+  `src/pubsub/**` the moment the module lands; otherwise M1–M5 run ungated.
+- **V6 (testing#3): circular oracle.** After repointing specs to the internal
+  singleton, hook tests use the module as both subject and oracle. Keep
+  `src/pubsub/pubsub.spec.ts` as the **permanent** independent module test, and
+  add `vi.spyOn(PubSub, 'publish')`-style assertions in hook tests where they add
+  signal independent of the bus round-trip.
+- **V7 (testing#5): add missing contract cases.** publish with **no data**
+  (`publish(token)` → handler gets `(token, undefined)`, returns true);
+  **double-unsubscribe** (2nd returns false, no throw); **cross-publish ordering**
+  (two `publish()` in one tick deliver A-then-B); **handler added during
+  dispatch** must not fire in the current dispatch (snapshot); assert
+  `unsubscribe`'s **return shape** (boolean). Add to MUST-HAVE.
+- **V8 (testing#1): symbol-identity baseline gap.** It can't pass against
+  pubsub-js, so land it in **M0 as `it.todo`/`skip`** (visible gap) and activate
+  on the internal module in M1/M2 — plus the V2 token-arg assertions.
+- **V9 (API#3 / testing#2): `subscribe` vs `on`; `subscribeOnce` return.**
+  `subscribe` (→ string token) is the **hook-internal/compat** path; new consumer
+  code should prefer `on` (→ unsubscribe fn). Mark `subscribe` `@internal` in
+  JSDoc. `subscribeOnce` returns a token (diverges from pubsub-js which returns
+  the bus) — document the divergence; do not claim it in "parity".
+- **V10 (testing#2): parity test is thin.** It can only cover the shared,
+  non-divergent surface (already covered by the contract suite). Keep it, but
+  every exclusion (symbol identity, dropped hierarchical, `subscribeOnce` return)
+  must be commented and linked to the non-parity test that covers it. Treat
+  parity as a *secondary* cross-check, not the primary safety net (the contract +
+  module specs are primary).
+- **V11 (API#8): `Message: any → unknown` moves to M4** (with the other
+  type-breaking changes) so "M4 = all breaking type changes" holds.
+
+## Accepted — MINOR
+
+- **V12 (API#7):** type `unsubscribe` with a real union, not the `(token: never,
+  data: never)` bottom-function trick.
+- **V13 (API#9):** add a negative test asserting the **default export is
+  `undefined`** after removal.
+- **V14 (testing#8):** standardize new spec files on
+  `beforeEach(vi.useFakeTimers)`/`afterEach(vi.useRealTimers)`; optionally align
+  the existing hook specs (cheap) to avoid cross-file timer-state leak.
+- **V15 (testing#9):** e2e smoke must import/assert the **new named exports**
+  (`createPubSub`) to cover the barrel re-export wiring (`src/index.ts` is
+  coverage-excluded).
+
+## Modified — R6 downgraded (React reviewer was right)
+
+- **V16 (React#1/#2): drop the `useLayoutEffect` swap (R6).** With `setTimeout(0)`
+  delivery the stale-handler window is unreachable (the existing "handler
+  changes" test proves `useEffect` works), and `useLayoutEffect` adds SSR/layout
+  cost for no observable gain. **Decision: leave the handler-ref `useEffect`
+  as-is in v2 core** (don't touch a working hook). Record the **render-time ref
+  write** (`handlerRef.current = handler` during render) and `useEffectEvent`
+  (19.2) as ideas (06); the render-time write is the preferred future
+  simplification if we ever touch it. So v2 core's only React change is **V3**
+  (memoize returns).
+
+## Elevated to the maintainer (genuine product decisions)
+
+- **V17 (API#1): `createPubSub` is disconnected from the hooks.** `PubSub` is
+  `createPubSub()` once at module scope; a consumer's `createPubSub<AppEvents>()`
+  is a **separate bus** the hooks don't use — a real footgun. Options (new Q7/Q8
+  in 07):
+  - **(a)** Defer `createPubSub` to v2.1; ship v2.0.0 as a clean dep-swap with the
+    lean `PubSub` + `on` only. (Smallest, safest.)
+  - **(b)** Ship `createPubSub` **and** add an optional `bus` param to the hooks
+    (`useSubscribe({ token, handler, bus? })`, default = singleton) so a typed bus
+    integrates end-to-end — the genuinely useful version. (Additive hook-API
+    change; more scope.)
+  - **(c)** Ship `createPubSub` standalone with very explicit "separate bus" docs.
+- **V18 (API#4 / Q1): hierarchical topics.** Dropping them is a *silent* runtime
+  break (handler never fires, no error) for consumers who used dotted topics from
+  the upstream docs. Either ship an opt-in `createPubSub({ hierarchical: true })`
+  **in v2.0.0** (small: ancestor-walk on publish) or accept the drop with a loud
+  CHANGELOG. **Maintainer's call (Q1).**
+
+## Upheld rejections (reviewers agreed)
+
+- `useSyncExternalStore`: not a fit for a push-event hook (all three implicitly
+  or explicitly agreed). Revisit only if the bus gains readable last-value state.
+- React 19 `use`: not applicable.
+
+## Noted (no action, recorded)
+
+- StrictMode unmount→remount window and `resubscribe` dep-array redundancy
+  (React#6/#7) are pre-existing and benign (delivery is a macrotask after
+  commit); left untouched, not claimed as "no risk" anymore.
+- `@types/react@19` type-shape differences would matter for a future `react19`
+  sub-path (06).
+
+## Net effect on the milestones
+See the updated 05/`milestones.yml`: example fix + build gate and the e2e smoke
+move into **M2/M1**; coverage thresholds into **M1**; `Message:any→unknown` into
+**M4**; the new contract cases into **M0/M1**; R6 removed; V3 `useMemo` added to
+the React milestone; Q1/Q7/Q8 block final API lock-in.

--- a/docs/migration-v2/08-review-verdicts.md
+++ b/docs/migration-v2/08-review-verdicts.md
@@ -137,6 +137,30 @@ extension; it isn't written, and `ci.yml` doesn't run e2e at all (only
 - `@types/react@19` type-shape differences would matter for a future `react19`
   sub-path (06).
 
+## Round-2 maintainer decisions (LOCKED)
+
+- **Q1 → KEEP hierarchical topics as DEFAULT.** Replicate pubsub-js's dotted
+  ancestor propagation (`publish('a.b.c')` notifies `a.b.c`, `a.b`, `a`) in the
+  default bus. This *removes* the silent-break risk (maximally compatible) but
+  adds scope and a design tension (below). Symbols match by **identity** (no
+  hierarchy); only string tokens get dotted propagation. Parity tests can now
+  cover hierarchical behavior (we match pubsub-js). Contract/module tests MUST
+  add ancestor-propagation cases.
+- **Q7 → DO NOT defer `createPubSub`.** Ship the typed API in v2.0.0. The
+  integration design (standalone vs hooks accept an optional `bus`) is delegated
+  to a **persona-lens critique round** (below) to recommend; then implement.
+- **Q8 → symbol delivery improvement confirmed** (handlers receive the original
+  symbol).
+
+### New design tension to resolve in the critique (hierarchical × typed)
+A typed `createPubSub<EventMap>()` keyed by exact `keyof E` does not naturally
+model hierarchical propagation: a subscriber to `'a'` typed as `E['a']` may now
+receive payloads published to `'a.b.c'` (type `E['a.b.c']`). Options to weigh:
+(i) hierarchical only on the untyped default `PubSub`, typed `createPubSub` stays
+flat; (ii) typed API models a parent payload as a union of descendants; (iii)
+hierarchical is a per-bus option `createPubSub({ hierarchical })` with relaxed
+(`unknown`) payloads for ancestor delivery. The critique recommends.
+
 ## Net effect on the milestones
 See the updated 05/`milestones.yml`: example fix + build gate and the e2e smoke
 move into **M2/M1**; coverage thresholds into **M1**; `Message:any→unknown` into

--- a/docs/migration-v2/09-lens-verdicts-and-impl-spec.md
+++ b/docs/migration-v2/09-lens-verdicts-and-impl-spec.md
@@ -1,0 +1,106 @@
+# 09 — Persona-lens verdicts, locked API, and M1 implementation spec
+
+Four persona lenses (API/DX, TypeScript types, performance/correctness,
+release-risk) critiqued the round-2 design. **All four returned GO-WITH-CHANGES.**
+The changes are M1 implementation refinements + doc fixes — **none block M0**.
+This doc is authoritative for the API shape and the M1 internal implementation.
+
+## Locked API (v2.0.0)
+
+- **Hierarchical × typed → option (i).** `createPubSub<E extends EventMap>()`
+  returns a **flat** typed bus (exact-key matching, exact payload types). The
+  default **`PubSub` singleton is untyped + hierarchical** (dotted ancestor
+  propagation) — satisfies the locked "hierarchical as default" decision without
+  the type-lie. The richer `HierarchicalPubSub<E>` (types lens's option iv) is
+  **reserved for v2.1** (additive).
+- **Public methods:** `publish`, `subscribe`(→ string token), `unsubscribe`,
+  `on`(→ unsubscribe fn, `{ signal? }`), `subscribeOnce`, `clearAllSubscriptions`.
+  Docs lead with **`on`/`subscribeOnce`** (modern); `subscribe`/`unsubscribe(token)`
+  are kept for pubsub-js drop-in compat (and used by the hooks). `clearAllSubscriptions`
+  documented as global (test/teardown use).
+- **`unsubscribe` signature:** `unsubscribe(value: string | ((...args: never[]) => unknown)): boolean`
+  (per types lens — not the `(never,never)=>void` form).
+- **Delivery:** async `setTimeout(0)`; handler receives the **original** token
+  (`string | symbol`) — `Listener<T> = (token: string | symbol, data: T) => void`.
+- **Hooks (v2.0.0):** only minimal changes — `useSubscribe` handler payload
+  `any → unknown`; `useMemo` both hook return objects (V3). The optional `bus`
+  param + `Events` generic + `usePublish` `message→data` rename are **reserved as
+  additive v2.1** (designed so they don't break later). Keeps v2 hook churn small.
+
+## M1 internal implementation spec (reference)
+
+Data structure: a forward index + a reverse index (perf lens).
+
+```ts
+const channels = new Map<string | symbol, Map<string, Listener>>()
+const tokenToChannel = new Map<string, string | symbol>()   // O(1) unsubscribe(token)
+let uid = 0
+```
+
+Rules (must-fixes from the perf lens, all internal):
+1. **Snapshot synchronously in `publish()`** — snapshot every hierarchy level's
+   subscribers *before* `setTimeout`, never inside the delivery callback. (Avoids
+   the unsubscribe-between-publish-and-delivery corruption.)
+2. **`publish` returns `false` if no subscriber exists at the token OR any
+   ancestor** (walk ancestors for the has-any check too).
+3. **Hierarchical walk (string tokens only):** notify exact token, then each
+   ancestor (`a.b.c` → `a.b` → `a`), closest-first. Symbols: identity only, no
+   hierarchy. Deliver the **original** published token to every handler (matches
+   pubsub-js; a handler subscribed at `a` receiving an `a.b.c` publish gets
+   `a.b.c`). A handler subscribed at multiple levels fires once per level
+   (documented, tested).
+4. **`unsubscribe(token)` O(1)** via `tokenToChannel`; `unsubscribe(handler)`
+   scans (rare). After removal, **delete the channel Map entry when empty**
+   (prevents strong-ref retention of symbol keys).
+5. **`subscribeOnce`** wrapper calls `unsubscribe(id)` **before** invoking the
+   handler (no leak if it throws).
+6. **`on(token, handler, { signal })`** returns a `cleanup` fn that both
+   unsubscribes and `removeEventListener('abort', cleanup)`; register the abort
+   listener with `{ once: true }`. (No listener leak on manual unsubscribe.)
+7. **Error isolation:** `try { fn(token, data) } catch (e) { setTimeout(() => { throw e }, 0) }`.
+8. **`clearAllSubscriptions()`:** `channels.clear(); tokenToChannel.clear()`.
+
+Reference `publish`:
+```ts
+function publish(token, data) {
+  const toNotify = [token]
+  if (typeof token === 'string') {
+    let t = token, pos
+    while ((pos = t.lastIndexOf('.')) !== -1) { t = t.slice(0, pos); toNotify.push(t) }
+  }
+  if (!toNotify.some(t => (channels.get(t)?.size ?? 0) > 0)) return false
+  const snapshots = []
+  for (const t of toNotify) { const m = channels.get(t); if (m?.size) snapshots.push([...m.values()]) }
+  setTimeout(() => {
+    for (const fns of snapshots) for (const fn of fns) {
+      try { fn(token, data) } catch (e) { setTimeout(() => { throw e }, 0) }
+    }
+  }, 0)
+  return true
+}
+```
+
+## M0/M1 test additions driven by the lenses
+- ancestor-delivery **order** (exact before ancestors);
+- **multi-level dedup** behavior (handler subscribed at `a` and `a.b` fires twice
+  for `a.b.c`) — documented + tested;
+- error-isolation test must **flush timers twice** (the rethrow is itself a faked
+  `setTimeout`) or assert via a `setTimeout` spy;
+- symbol-identity (two `Symbol('x')` don't cross-deliver) — `it.todo` in M0
+  (fails vs pubsub-js), active on the module in M1;
+- the existing perf-lens cases (no-data publish, double-unsubscribe, cross-publish
+  ordering, snapshot/handler-added-during-dispatch, unsubscribe return shape).
+
+## Pre-M0 doc fixes (applied)
+1. `milestones.yml`: `Message any→unknown` is **M4**, not M2.
+2. Hierarchical×typed decision (option i) written into 07.
+3. Hierarchical-propagation contract tests added to **M0** (pubsub-js supports
+   them today → they pass against the current backend).
+4. **M3 folded into M2** (R6 dropped; the only v2 React change, `useMemo`, lives
+   with the swap).
+
+## Verdicts (one line each)
+- API/DX: GO-WITH-CHANGES — collapse duality toward `on`/`once`; flat typed bus.
+- Types: GO-WITH-CHANGES — option (i) sound; fix `unsubscribe` type; reserve generics.
+- Performance: GO-WITH-CHANGES — 8 internal must-fixes above; architecture sound.
+- Risk: GO — start M0 after the 4 doc fixes; biggest residual = decide hierarchical×typed (now done).

--- a/docs/migration-v2/README.md
+++ b/docs/migration-v2/README.md
@@ -20,7 +20,14 @@ before any code is written.
 | [05-milestones.md](./05-milestones.md) | Step-by-step execution as PR-sized milestones with verification gates. |
 | [06-ideas-backlog.md](./06-ideas-backlog.md) | Version-specific / future progressive-enhancement ideas to "save". |
 | [07-decisions-and-risks.md](./07-decisions-and-risks.md) | Decision log (what I decided and why), open questions for the maintainer, risks. |
+| [08-review-verdicts.md](./08-review-verdicts.md) | **Authoritative.** Adjudication of the 3 adversarial reviews + the resulting amendments. Where it conflicts with 01–07, 08 wins. |
 | [milestones.yml](./milestones.yml) | Machine-readable milestone/checklist mirror of 05, for execution tracking. |
+
+> **Read 08 first.** The plan was put through three adversarial reviews; 08
+> records every verdict and the amendments (two BLOCKERs were verified against the
+> code: the `example/` app breaks on the dep removal, and the `String(token)`
+> delivery contradicts the typed API). 01–07 are the original draft; 08 is the
+> corrected plan of record.
 
 ## Non-negotiable constraints (carried from the whole project)
 

--- a/docs/migration-v2/README.md
+++ b/docs/migration-v2/README.md
@@ -1,0 +1,48 @@
+# use-pubsub-js v2 — migration & improvement plan
+
+**Goal:** replace the single runtime dependency `pubsub-js` with an internal,
+zero-dependency TypeScript pub/sub module, and bundle in the React-side
+improvements + the deferred semver-major cleanups — all in one **v2.0.0**.
+
+This folder is the plan. It was synthesized from five parallel research passes
+(pubsub-js surface & usage, new-API design, React perf/integration, testing
+strategy, packaging/DX) and is meant to be reviewed milestone-by-milestone
+before any code is written.
+
+## Documents
+
+| File | What |
+| --- | --- |
+| [01-api-design.md](./01-api-design.md) | The internal module: lean `PubSub` + typed `createPubSub` + `on`/AbortSignal; what's kept/dropped from pubsub-js; behaviors that must match. |
+| [02-react-improvements.md](./02-react-improvements.md) | React-side improvements + version-gating (React 17 floor, opt-in React 19.2 lane). |
+| [03-testing-strategy.md](./03-testing-strategy.md) | Contract-gap tests, in-isolation module tests, differential/parity test, smoke tests, CI. |
+| [04-packaging-dx.md](./04-packaging-dx.md) | Dependency removal, exports map, types, build, CHANGELOG/migration notes, metadata. |
+| [05-milestones.md](./05-milestones.md) | Step-by-step execution as PR-sized milestones with verification gates. |
+| [06-ideas-backlog.md](./06-ideas-backlog.md) | Version-specific / future progressive-enhancement ideas to "save". |
+| [07-decisions-and-risks.md](./07-decisions-and-risks.md) | Decision log (what I decided and why), open questions for the maintainer, risks. |
+| [milestones.yml](./milestones.yml) | Machine-readable milestone/checklist mirror of 05, for execution tracking. |
+
+## Non-negotiable constraints (carried from the whole project)
+
+1. **The public hook API** — `usePublish` / `useSubscribe` names, params, return
+   shapes — and the pub/sub subscribe/unsubscribe/publish **runtime behavior**
+   must not regress. The 41-test suite (incl. the pub/sub *contract* suite) is
+   the safety net; never make a test pass by weakening it.
+2. **Async delivery** stays `setTimeout(0)` (not microtasks) — the tests pin it
+   and consumers depend on "publish returns before handlers run".
+3. **React floor is `>=17`** (peer dep). Newer-React features are opt-in /
+   gated so older-React users never break.
+4. **Zero runtime dependencies** is the headline win — don't reintroduce one.
+
+## Locked decisions (from the maintainer)
+
+- **Lean public API**, but also ship a **better, typed** API (`createPubSub`) —
+  see 01.
+- **Single big v2.0.0**: dependency swap + React improvements + the semver-major
+  type cleanups land together.
+
+## How to read / use this
+
+Start with [07-decisions-and-risks.md](./07-decisions-and-risks.md) for the
+decision log and open questions, then [05-milestones.md](./05-milestones.md) for
+the execution order. The other docs are the detail behind each decision.

--- a/docs/migration-v2/milestones.yml
+++ b/docs/migration-v2/milestones.yml
@@ -1,4 +1,15 @@
 # Machine-readable mirror of 05-milestones.md — for execution tracking.
+# NOTE: amended by 08-review-verdicts.md (authoritative). Key deltas:
+#  - M0: symbol-identity test as it.todo; add contract cases (no-data publish,
+#        double-unsubscribe, cross-publish ordering, handler-added-during-dispatch,
+#        unsubscribe return shape).
+#  - M1: coverage thresholds enabled here (not M6); e2e runtime smoke written here;
+#        deliver original token (not String(token)); pubsub.spec.ts is permanent.
+#  - M2: UPDATE example/src/service/publish.ts to import { PubSub } from 'use-pubsub-js';
+#        add `pnpm --prefix ./example build` to CI gate; add useMemo to hook returns (R3).
+#        (R6 useLayoutEffect DROPPED.)
+#  - M4: Message any->unknown moves here (with the other type breaks).
+#  - Blocked on maintainer: Q1 (hierarchical), Q7 (createPubSub/bus), Q8 (symbol delivery).
 # status: planned | in_progress | done
 version_target: 2.0.0
 sequencing: single-major-as-ordered-prs

--- a/docs/migration-v2/milestones.yml
+++ b/docs/migration-v2/milestones.yml
@@ -1,0 +1,80 @@
+# Machine-readable mirror of 05-milestones.md — for execution tracking.
+# status: planned | in_progress | done
+version_target: 2.0.0
+sequencing: single-major-as-ordered-prs
+constraints:
+  - public hook API + pub/sub runtime behavior unchanged (except documented intentional differences)
+  - delivery stays setTimeout(0) async
+  - react floor >=17; newer-react features opt-in/gated
+  - zero runtime dependencies at release
+
+milestones:
+  - id: M0
+    title: Contract safety net against current pubsub-js
+    status: planned
+    changes:
+      - add contract-gap tests (delivery order, error isolation, unsubscribe-during-delivery, re-entrancy, clearAllSubscriptions)
+    gate: [build, test, lint, e2e, review, ci]
+  - id: M1
+    title: Build internal module (not wired into hooks)
+    status: planned
+    changes:
+      - src/pubsub/index.ts (PubSub, createPubSub, on, subscribeOnce, unsubscribe(token|handler), clearAllSubscriptions)
+      - src/pubsub/pubsub.spec.ts (in-isolation unit tests)
+      - src/pubsub/parity.spec.ts (differential vs pubsub-js; pubsub-js kept as devDep)
+    gate: [build, test, attw, publint, review, ci]
+  - id: M2
+    title: Swap hooks + index to internal module (riskiest)
+    status: planned
+    changes:
+      - useSubscribe/usePublish/index import ../pubsub; repoint spec oracles
+      - remove pubsub-js from dependencies (keep devDep for parity until M6)
+      - Message any -> unknown
+    gate: [build, test, lint, e2e, parity, review, ci]
+  - id: M3
+    title: React correctness (R6) + return-stability docs
+    status: planned
+    changes:
+      - useSubscribe dep-less useEffect -> useIsomorphicLayoutEffect
+      - README destructure-return note
+    gate: [build, test, lint, e2e, review, ci]
+  - id: M4
+    title: Semver-major cleanups
+    status: planned
+    changes:
+      - debounce.ts drop @ts-nocheck, narrow generic (#4)
+      - rename IUsePublish* -> UsePublish* (#5)
+      - remove default export barrel (#8)
+      - keep debounceMs number|string (#7 decided: no narrow)
+    gate: [build, test, lint, e2e, attw, publint, review, ci]
+  - id: M5
+    title: Packaging - ./pubsub subpath + types + metadata
+    status: planned
+    changes:
+      - exports ./pubsub + typesVersions entry
+      - drop empty dependencies key + @types/pubsub-js
+      - description/keywords update
+    gate: [attw, publint, frozen-install, e2e-smoke, review, ci]
+  - id: M6
+    title: Docs + migration notes + remove scaffolding
+    status: planned
+    changes:
+      - README rewrite + CHANGELOG migration section
+      - remove parity.spec.ts + pubsub-js devDep (zero-dep)
+      - vitest coverage thresholds 100%
+    gate: [build, test, lint, e2e, audit, review, ci]
+  - id: M7
+    title: Release v2.0.0 (maintainer-triggered; not by the agent)
+    status: planned
+    changes:
+      - confirm changelog reads as major; trigger OIDC release workflow
+      - optional react19 useEffectEvent sub-path (Q3)
+    gate: [maintainer-approval]
+
+open_questions:
+  - Q1: drop hierarchical/dotted topics? (default: drop + document)
+  - Q2: symbol identity vs stringify? (default: identity)
+  - Q3: ship react19 useEffectEvent sub-path in v2.0.0 or v2.1?
+  - Q4: keep or remove parity test + pubsub-js devDep at release? (default: remove)
+  - Q5: add optional typed Events generic to hooks in v2? (default: defer)
+  - Q6: keep subscribeOnce + unsubscribe(handler), or go fully minimal? (default: keep)

--- a/docs/migration-v2/milestones.yml
+++ b/docs/migration-v2/milestones.yml
@@ -24,38 +24,45 @@ milestones:
     title: Contract safety net against current pubsub-js
     status: planned
     changes:
-      - add contract-gap tests (delivery order, error isolation, unsubscribe-during-delivery, re-entrancy, clearAllSubscriptions)
+      - contract-gap tests (delivery order, error isolation [flush timers twice],
+        unsubscribe-during-delivery, re-entrancy, clearAllSubscriptions)
+      - hierarchical-propagation tests (ancestor order; multi-level dedup) — pass vs pubsub-js today
+      - more cases (08-V7) no-data publish, double-unsubscribe, cross-publish ordering, unsubscribe return shape
+      - symbol-identity test as it.todo (fails vs pubsub-js; activated on the module in M1)
     gate: [build, test, lint, e2e, review, ci]
   - id: M1
     title: Build internal module (not wired into hooks)
     status: planned
     changes:
-      - src/pubsub/index.ts (PubSub, createPubSub, on, subscribeOnce, unsubscribe(token|handler), clearAllSubscriptions)
-      - src/pubsub/pubsub.spec.ts (in-isolation unit tests)
-      - src/pubsub/parity.spec.ts (differential vs pubsub-js; pubsub-js kept as devDep)
-    gate: [build, test, attw, publint, review, ci]
+      - src/pubsub/index.ts per 09 impl spec (forward+reverse index; sync snapshot of
+        ALL hierarchy levels in publish; hierarchical walk for string tokens; symbol
+        identity; on/{signal} with abort-listener cleanup; subscribeOnce unsub-before-call;
+        delete empty channels; unsubscribe(value: string | ((...args:never[])=>unknown)))
+      - createPubSub<E> = FLAT typed bus; PubSub singleton = untyped + hierarchical (option i)
+      - src/pubsub/pubsub.spec.ts (in-isolation unit tests; permanent independent oracle)
+      - src/pubsub/parity.spec.ts (differential vs pubsub-js incl. hierarchical; pubsub-js devDep)
+      - activate symbol-identity test; e2e behavioral smoke (async ~10ms, asserts createPubSub)
+      - enable vitest coverage thresholds here (100% on src/pubsub/**) — 08-V5
+    gate: [build, test, attw, publint, coverage-threshold, review, ci]
   - id: M2
-    title: Swap hooks + index to internal module (riskiest)
+    title: Swap hooks + index to internal module (riskiest) + R3 useMemo
     status: planned
     changes:
       - useSubscribe/usePublish/index import ../pubsub; repoint spec oracles
       - remove pubsub-js from dependencies (keep devDep for parity until M6)
-      - Message any -> unknown
-    gate: [build, test, lint, e2e, parity, review, ci]
-  - id: M3
-    title: React correctness (R6) + return-stability docs
-    status: planned
-    changes:
-      - useSubscribe dep-less useEffect -> useIsomorphicLayoutEffect
-      - README destructure-return note
-    gate: [build, test, lint, e2e, review, ci]
+      - update example/src/service/publish.ts -> import { PubSub } from 'use-pubsub-js' (08-V1)
+      - add `pnpm --prefix ./example build` to CI gate (08-V1)
+      - useMemo both hook return objects (R3, 08-V3)  [folded-in former M3; R6 dropped]
+    gate: [build, test, lint, e2e, parity, example-build, review, ci]
+  # M3 (R6 useLayoutEffect) DROPPED per 08-V16; its only survivor (useMemo) is in M2.
   - id: M4
-    title: Semver-major cleanups
+    title: Semver-major type cleanups
     status: planned
     changes:
+      - Message any -> unknown in useSubscribe handler (moved here from M2, 08-V11)
       - debounce.ts drop @ts-nocheck, narrow generic (#4)
       - rename IUsePublish* -> UsePublish* (#5)
-      - remove default export barrel (#8)
+      - remove default export barrel (#8) + negative test default===undefined (08-V13)
       - keep debounceMs number|string (#7 decided: no narrow)
     gate: [build, test, lint, e2e, attw, publint, review, ci]
   - id: M5
@@ -82,10 +89,13 @@ milestones:
       - optional react19 useEffectEvent sub-path (Q3)
     gate: [maintainer-approval]
 
+resolved:
+  - Q1: KEEP hierarchical as default (on untyped PubSub; createPubSub flat) — maintainer
+  - Q2: symbol identity (confirmed)
+  - Q7: ship createPubSub in v2 (flat typed); HierarchicalPubSub reserved for v2.1
+  - Q8: handlers receive the original symbol token (confirmed)
 open_questions:
-  - Q1: drop hierarchical/dotted topics? (default: drop + document)
-  - Q2: symbol identity vs stringify? (default: identity)
-  - Q3: ship react19 useEffectEvent sub-path in v2.0.0 or v2.1?
+  - Q3: ship react19 useEffectEvent sub-path in v2.0.0 or v2.1? (default: v2.1)
   - Q4: keep or remove parity test + pubsub-js devDep at release? (default: remove)
-  - Q5: add optional typed Events generic to hooks in v2? (default: defer)
-  - Q6: keep subscribeOnce + unsubscribe(handler), or go fully minimal? (default: keep)
+  - Q5: add optional typed Events generic + bus param to hooks in v2 or v2.1? (default: v2.1, additive)
+  - Q6: keep subscribeOnce + unsubscribe(handler)? (default: keep for compat)


### PR DESCRIPTION
## v2 migration plan & design record

The full planning artifact behind the v2 internal-pub/sub migration (now implemented in #70–#75): research synthesis, the API design, React/perf/testing/packaging strategies, milestones, the adversarial-review verdicts, and the persona-lens implementation spec. Preserved on `main` as the design rationale for v2.0.0.

Docs-only (no code). `docs/migration-v2/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)