### PR TITLE
feat(hooks)!: typed bus param + Events generic; widen message; rename useSubscribe types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ dist
 .rpt2_cache
 coverage
 
+# packaging artifacts (pnpm pack / attw --pack)
+*.tgz
+
 # misc
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ More real examples:
 | isUnsubscribe | Is the way to dynamically unsubscribe and subscribe based on some variable | boolean                                         | false            |
 | bus           | The bus to subscribe on; pass a `createPubSub<E>()` bus for typed payloads | PubSubBus \| TypedPubSub\<E\>                    | PubSub singleton |
 
+> The `handler` `message` is `unknown` by default; when a typed `bus` is passed
+> it is narrowed to the payload type for that token (`Events[token]`).
+
 * Returns of `useSubscribe`
 
 | key         | description                                                                                                         | type       |

--- a/README.md
+++ b/README.md
@@ -160,9 +160,24 @@ export const bus = createPubSub<AppEvents>()
 bus.publish('user:login', { userId: '42' }) // payload is type-checked
 ```
 
-> Note: `createPubSub()` returns a **separate** bus instance. The hooks use the
-> default `PubSub` singleton; pass data through it (or wire your typed bus into
-> your own context) if you need the hooks and a typed bus to share state.
+Both hooks accept an optional `bus` param so they can drive a typed bus with
+full end-to-end inference (the `token` and `message`/`handler` payload are typed
+from the event map):
+
+```tsx
+import { usePublish, useSubscribe } from 'use-pubsub-js'
+import { bus } from './bus'
+
+// message is type-checked as { userId: string }
+usePublish({ bus, token: 'user:login', message: { userId: '42' } })
+
+// handler's second arg is inferred as { userId: string }
+useSubscribe({ bus, token: 'user:login', handler: (_, user) => console.log(user.userId) })
+```
+
+> Note: `createPubSub()` returns a **separate** bus instance. Omit `bus` (or
+> leave it as the default) to use the shared `PubSub` singleton. Keep the `bus`
+> reference stable (e.g. module scope) — changing it re-subscribes/re-publishes.
 
 ### Migrating from v1 to v2
 
@@ -171,10 +186,17 @@ bus.publish('user:login', { userId: '42' }) // payload is type-checked
   singleton — in v2 the bus is independent, so import `PubSub` only from
   `use-pubsub-js` for a single shared bus.
 - The subscriber `message` payload type is now `unknown` (was `any`) — narrow or
-  cast it in your handler.
+  cast it in your handler. `usePublish`'s `message` is likewise widened from
+  `string` to `unknown`, so you can publish any payload through the hook.
 - The default export was removed — use named imports.
 - `IUsePublishParams`/`IUsePublishResponse` were renamed to
   `UsePublishParams`/`UsePublishResponse`.
+- The `useSubscribe` types `UseSubscriptionParams`/`UseSubscriptionResponse`
+  were renamed to `UseSubscribeParams`/`UseSubscribeResponse` for parity with
+  the `usePublish` types.
+- Both hooks now accept an optional `bus` param (defaults to the `PubSub`
+  singleton), so a `createPubSub<E>()` bus can be driven through the hooks with
+  typed payloads.
 - Symbol tokens match by identity (two distinct `Symbol('x')` no longer collide).
 - Removed rarely-used pubsub-js extras (`publishSync`, `subscribeAll`/`*`
   wildcard, `clearSubscriptions(topic)`, `countSubscriptions`,
@@ -203,6 +225,7 @@ More real examples:
 | token         | Token is used to subscribe listen a specific publisher                     | string \| symbol                                | required         |
 | handler       | Function that is going to be executed when a publication occurs            | (token: string \| symbol, message: unknown) => void | required         |
 | isUnsubscribe | Is the way to dynamically unsubscribe and subscribe based on some variable | boolean                                         | false            |
+| bus           | The bus to subscribe on; pass a `createPubSub<E>()` bus for typed payloads | PubSubBus \| TypedPubSub\<E\>                    | PubSub singleton |
 
 * Returns of `useSubscribe`
 
@@ -218,11 +241,12 @@ More real examples:
 | key              | description                                                             | type             | default/required |
 | ---------------- | ----------------------------------------------------------------------- | ---------------- | ---------------- |
 | token            | Token is used to subscribe listen a specific publisher                  | string \| symbol | required         |
-| message          | The value that will be send to subscriber                               | any              | required         |
+| message          | The value that will be send to subscriber                               | unknown          | required         |
 | isAutomatic      | Whether the publication should be automatic                             | boolean          | false            |
 | isInitialPublish | Whether to make a publication in the first render                       | boolean          | false            |
 | isImmediate      | To disable debounce and publish without delay any change in the message | boolean          | false            |
 | debounceMs       | The delay value                                                         | number \| string | 300              |
+| bus              | The bus to publish on; pass a `createPubSub<E>()` bus for typed payloads | PubSubBus \| TypedPubSub\<E\>                    | PubSub singleton |
 
 * Returns of usePublish
 

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
 
 packages:
 
-  pubsub-js@1.9.5:
-    resolution: {integrity: sha512-5MZ0I9i5JWVO7SizvOviKvZU2qaBbl2KQX150FAA+fJBwYpwOUId7aNygURWSdPzlsA/xZ/InUKXqBbzM0czTA==}
-
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
@@ -25,15 +22,12 @@ packages:
     resolution: {directory: .., type: directory}
     engines: {node: '>=18'}
     peerDependencies:
-      react: '>17.0.2'
+      react: '>=17.0.0'
 
 snapshots:
-
-  pubsub-js@1.9.5: {}
 
   react@19.1.1: {}
 
   use-pubsub-js@file:..(react@19.1.1):
     dependencies:
-      pubsub-js: 1.9.5
       react: 19.1.1

--- a/src/hooks/pubsub-integration.spec.ts
+++ b/src/hooks/pubsub-integration.spec.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { PubSub } from '../pubsub'
+import { createPubSub, PubSub } from '../pubsub'
 import { usePublish } from './usePublish'
 import { useSubscribe } from './useSubscribe'
 
@@ -43,5 +43,100 @@ describe('usePublish + useSubscribe integration', () => {
 
     expect(handler).toBeCalledTimes(1)
     expect(handler).toHaveBeenCalledWith(token, message)
+  })
+
+  it('publishes a non-string payload through usePublish', () => {
+    const handler = vi.fn()
+    const payload = { count: 3 }
+
+    renderHook(() => useSubscribe({ token, handler }))
+    const { result } = renderHook(() => usePublish({ token, message: payload }))
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toHaveBeenCalledWith(token, payload)
+  })
+})
+
+describe('usePublish + useSubscribe with a custom bus', () => {
+  // biome-ignore lint/style/useConsistentTypeDefinitions: must be a type alias, not an interface — createPubSub<E extends EventMap> requires the implicit index signature that interfaces lack
+  type AppEvents = {
+    'user:login': { userId: string }
+  }
+
+  it('routes typed payloads through a createPubSub bus', () => {
+    const bus = createPubSub<AppEvents>()
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ bus, token: 'user:login', handler }))
+    const { result } = renderHook(() =>
+      usePublish({ bus, token: 'user:login', message: { userId: '42' } }),
+    )
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toHaveBeenCalledWith('user:login', { userId: '42' })
+  })
+
+  it('isolates a custom bus from the default PubSub singleton', () => {
+    const bus = createPubSub<AppEvents>()
+    const customHandler = vi.fn()
+    const defaultHandler = vi.fn()
+
+    renderHook(() =>
+      useSubscribe({ bus, token: 'user:login', handler: customHandler }),
+    )
+    renderHook(() =>
+      useSubscribe({ token: 'user:login', handler: defaultHandler }),
+    )
+    const { result } = renderHook(() =>
+      usePublish({ bus, token: 'user:login', message: { userId: '42' } }),
+    )
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(customHandler).toBeCalledTimes(1)
+    expect(defaultHandler).toBeCalledTimes(0)
+  })
+
+  it('re-subscribes on the new bus when the bus reference changes', () => {
+    const busA = createPubSub<AppEvents>()
+    const busB = createPubSub<AppEvents>()
+    const handler = vi.fn()
+    let currentBus = busA
+
+    const { rerender } = renderHook(() =>
+      useSubscribe({ bus: currentBus, token: 'user:login', handler }),
+    )
+
+    act(() => {
+      busA.publish('user:login', { userId: 'a' })
+      vi.advanceTimersByTime(0)
+    })
+    expect(handler).toBeCalledTimes(1)
+
+    currentBus = busB
+    rerender()
+
+    act(() => {
+      busA.publish('user:login', { userId: 'a' })
+      vi.advanceTimersByTime(0)
+    })
+    expect(handler).toBeCalledTimes(1) // old bus no longer delivers
+
+    act(() => {
+      busB.publish('user:login', { userId: 'b' })
+      vi.advanceTimersByTime(0)
+    })
+    expect(handler).toBeCalledTimes(2) // new bus delivers
   })
 })

--- a/src/hooks/pubsub-integration.spec.ts
+++ b/src/hooks/pubsub-integration.spec.ts
@@ -108,6 +108,44 @@ describe('usePublish + useSubscribe with a custom bus', () => {
     expect(defaultHandler).toBeCalledTimes(0)
   })
 
+  it('delivers automatic publishes through a custom bus', () => {
+    const bus = createPubSub<AppEvents>()
+    const handler = vi.fn()
+
+    renderHook(() => useSubscribe({ bus, token: 'user:login', handler }))
+    renderHook(() =>
+      usePublish({
+        bus,
+        token: 'user:login',
+        message: { userId: '42' },
+        isAutomatic: true,
+      }),
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+
+    expect(handler).toHaveBeenCalledWith('user:login', { userId: '42' })
+  })
+
+  it('cleans up the custom-bus subscription on unmount', () => {
+    const bus = createPubSub<AppEvents>()
+    const handler = vi.fn()
+
+    const { unmount } = renderHook(() =>
+      useSubscribe({ bus, token: 'user:login', handler }),
+    )
+    unmount()
+
+    act(() => {
+      bus.publish('user:login', { userId: '42' })
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+  })
+
   it('re-subscribes on the new bus when the bus reference changes', () => {
     const busA = createPubSub<AppEvents>()
     const busB = createPubSub<AppEvents>()

--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -189,6 +189,27 @@ describe('usePublish', () => {
 
     expect(handler).toBeCalledTimes(0)
   })
+  it('publishes automatically for valid falsy payloads (0, false)', () => {
+    const zeroHandler = vi.fn()
+    const falseHandler = vi.fn()
+
+    PubSub.subscribe('zero', zeroHandler)
+    PubSub.subscribe('flag', falseHandler)
+
+    renderHook(() =>
+      usePublish({ token: 'zero', message: 0, isAutomatic: true }),
+    )
+    renderHook(() =>
+      usePublish({ token: 'flag', message: false, isAutomatic: true }),
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+
+    expect(zeroHandler).toHaveBeenCalledWith('zero', 0)
+    expect(falseHandler).toHaveBeenCalledWith('flag', false)
+  })
   it('falls back to the default delay when debounceMs is not a number', () => {
     const handler = vi.fn()
 

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -63,7 +63,12 @@ export const usePublish = <
   useEffect(() => {
     const wait = Number.isFinite(+debounceMs) ? +debounceMs : 300
     const debouncedPublished = debounce(publish, wait, isImmediate)
-    if (isAutomatic && message) {
+    // Skip auto-publish only for the "unset" sentinels (undefined/null/empty
+    // string). Now that `message` is `unknown`, a plain truthiness check would
+    // wrongly swallow valid falsy payloads like 0 or false.
+    const hasMessage =
+      message !== undefined && message !== null && message !== ''
+    if (isAutomatic && hasMessage) {
       debouncedPublished()
     }
     return () => {

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { PubSub } from '../pubsub'
+import {
+  type EventMap,
+  PubSub,
+  type PubSubBus,
+  type TypedPubSub,
+} from '../pubsub'
 import { debounce } from '../utils/debounce'
 
 export interface UsePublishResponse {
@@ -7,31 +12,45 @@ export interface UsePublishResponse {
   publish: () => void
 }
 
-export interface UsePublishParams<TokenType extends string | symbol> {
+export interface UsePublishParams<
+  TokenType extends string | symbol,
+  Events extends EventMap = EventMap,
+> {
+  /**
+   * The bus to publish on. Defaults to the shared `PubSub` singleton; pass a
+   * bus from `createPubSub<Events>()` for typed payloads. Keep the reference
+   * stable (e.g. module scope) — changing it re-creates the publisher.
+   */
+  bus?: PubSubBus | TypedPubSub<Events>
   debounceMs?: number | string
   isAutomatic?: boolean
   isImmediate?: boolean
   isInitialPublish?: boolean
-  message: string
+  message: TokenType extends keyof Events ? Events[TokenType] : unknown
   token: TokenType
 }
 
-export const usePublish = <TokenType extends string | symbol>({
+export const usePublish = <
+  TokenType extends string | symbol,
+  Events extends EventMap = EventMap,
+>({
   token,
   message,
   isAutomatic = false,
   isInitialPublish = false,
   isImmediate = false,
   debounceMs = 300,
-}: UsePublishParams<TokenType>): UsePublishResponse => {
+  bus = PubSub,
+}: UsePublishParams<TokenType, Events>): UsePublishResponse => {
+  const activeBus = bus as PubSubBus
   const [lastPublish, setLastPublish] = useState(false)
   const didInitialPublish = useRef(false)
 
   const publish = useCallback(() => {
-    const isPublished = PubSub.publish(token, message)
+    const isPublished = activeBus.publish(token, message)
 
     setLastPublish(isPublished)
-  }, [token, message])
+  }, [activeBus, token, message])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: runs once on mount when isInitialPublish is set; the empty dep array and the ref guard keep it single-fire even under StrictMode's double-invoke
   useEffect(() => {

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -1,24 +1,44 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { PubSub } from '../pubsub'
+import {
+  type EventMap,
+  PubSub,
+  type PubSubBus,
+  type TypedPubSub,
+} from '../pubsub'
 
-type Message = unknown
-
-export interface UseSubscriptionResponse {
+export interface UseSubscribeResponse {
   resubscribe: () => void
   unsubscribe: () => void
 }
 
-export interface UseSubscriptionParams<TokenType extends string | symbol> {
-  handler: (token: TokenType, message: Message) => void
+export interface UseSubscribeParams<
+  TokenType extends string | symbol,
+  Events extends EventMap = EventMap,
+> {
+  /**
+   * The bus to subscribe on. Defaults to the shared `PubSub` singleton; pass a
+   * bus from `createPubSub<Events>()` for typed payloads. Keep the reference
+   * stable (e.g. module scope) — changing it re-subscribes.
+   */
+  bus?: PubSubBus | TypedPubSub<Events>
+  handler: (
+    token: TokenType,
+    message: TokenType extends keyof Events ? Events[TokenType] : unknown,
+  ) => void
   isUnsubscribe?: boolean
   token: TokenType
 }
 
-export const useSubscribe = <TokenType extends string | symbol>({
+export const useSubscribe = <
+  TokenType extends string | symbol,
+  Events extends EventMap = EventMap,
+>({
   token,
   handler,
   isUnsubscribe = false,
-}: UseSubscriptionParams<TokenType>): UseSubscriptionResponse => {
+  bus = PubSub,
+}: UseSubscribeParams<TokenType, Events>): UseSubscribeResponse => {
+  const activeBus = bus as PubSubBus
   const handlerRef = useRef(handler)
   const subscriptionToken = useRef<string | null>(null)
 
@@ -26,21 +46,24 @@ export const useSubscribe = <TokenType extends string | symbol>({
     handlerRef.current = handler
   })
 
-  const internalHandler = useCallback((msg: string | symbol, data: Message) => {
-    handlerRef.current(msg as TokenType, data)
+  const internalHandler = useCallback((msg: string | symbol, data: unknown) => {
+    handlerRef.current(
+      msg as TokenType,
+      data as TokenType extends keyof Events ? Events[TokenType] : unknown,
+    )
   }, [])
 
   const unsubscribe = useCallback(() => {
     if (subscriptionToken.current) {
-      PubSub.unsubscribe(subscriptionToken.current)
+      activeBus.unsubscribe(subscriptionToken.current)
       subscriptionToken.current = null
     }
-  }, [])
+  }, [activeBus])
 
   const resubscribe = useCallback(() => {
     unsubscribe()
-    subscriptionToken.current = PubSub.subscribe(token, internalHandler)
-  }, [token, internalHandler, unsubscribe])
+    subscriptionToken.current = activeBus.subscribe(token, internalHandler)
+  }, [activeBus, token, internalHandler, unsubscribe])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: token is kept explicit even though resubscribe/unsubscribe already close over it; preserves the original re-subscribe-on-token-change intent
   useEffect(() => {

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -46,6 +46,9 @@ export const useSubscribe = <
     handlerRef.current = handler
   })
 
+  // The bus delivers `(string | symbol, unknown)`. The casts narrow back to the
+  // caller's declared token/payload types — sound by construction: a typed bus
+  // only ever delivers the payload registered for that token.
   const internalHandler = useCallback((msg: string | symbol, data: unknown) => {
     handlerRef.current(
       msg as TokenType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 export type { UsePublishParams, UsePublishResponse } from './hooks/usePublish'
 export { usePublish } from './hooks/usePublish'
 export type {
-  UseSubscriptionParams,
-  UseSubscriptionResponse,
+  UseSubscribeParams,
+  UseSubscribeResponse,
 } from './hooks/useSubscribe'
 export { useSubscribe } from './hooks/useSubscribe'
 export type {


### PR DESCRIPTION
## What & why

Closes the main DX gap in the v2 design: `createPubSub<E>()` produced a fully-typed bus that the hooks **could not consume** (they hard-coded the untyped `PubSub` singleton). This PR wires typed buses through both hooks and finalizes two breaking cleanups for the 2.0.0 window (maintainer-approved).

All changes are **additive for existing no-`bus` callers** — the default path is byte-for-byte equivalent to before.

### Changes
- **`bus?` param** on `usePublish`/`useSubscribe` (defaults to the `PubSub` singleton) — drive a `createPubSub<E>()` bus through the hooks.
- **`Events` generic** for end-to-end inference: `token`, `message`, and the `handler` arg are typed from the event map (defaults preserve untyped `unknown` behavior).
- **Widen `usePublish` `message`** from `string` → `unknown` (matches `PubSub.publish<T>`). _Breaking._
- **Rename** `UseSubscriptionParams`/`UseSubscriptionResponse` → `UseSubscribeParams`/`UseSubscribeResponse` for parity with `UsePublish*`. _Breaking (type-only)._
- README: bus param, typed-hooks example, API tables, migration notes. `.gitignore`: `*.tgz`.

### Review-driven fixes (adversarial subagent)
- **MAJOR fixed:** widening `message` made the `isAutomatic && message` guard silently swallow valid falsy payloads (`0`, `false`). Guard now skips only the unset sentinels (`undefined`/`null`/`''`). **Mutation-verified** — the new test fails against the old guard.
- Added custom-bus integration tests: typed delivery, isolation from the default singleton, re-subscribe on bus change, unmount cleanup, automatic publish, non-string payload.
- Documented why the `internalHandler` casts are sound by construction.

> The reviewer's other MAJOR (removed type names without a deprecated alias) is **intentional** — this ships in the single 2.0.0 major, documented in the migration guide. Not adding a shim, per the lean-API decision.

## Verification
- 94 tests pass · 100% coverage (all axes)
- `pnpm lint` clean · lib build + example build green · e2e 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)