### PR TITLE
ci: gate releases and CI on lint + e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         pnpm build
         pnpm --prefix ./example build
 
+    - name: End-to-end import smoke tests (CJS/ESM)
+      run: pnpm test:e2e
+
     - name: Coveralls
       uses: coverallsapp/github-action@v2
       with:

--- a/.release-it.json
+++ b/.release-it.json
@@ -11,7 +11,7 @@
     "releaseName": "Release v${version}"
   },
   "hooks": {
-    "before:init": "pnpm test"
+    "before:init": "pnpm lint && pnpm test --run && pnpm test:e2e"
   },
   "plugins": {
     "release-it-pnpm": {


### PR DESCRIPTION
The release `before:init` hook ran only `pnpm test`, and CI never ran the e2e import smoke tests — a broken CJS/ESM export or a lint error could reach npm.

- **`.release-it.json`** `before:init` → `pnpm lint && pnpm test --run && pnpm test:e2e` (explicit `--run` so it can't hang in watch mode). Gates both the GitHub release workflow and any manual `pnpm release`.
- **`ci.yml`** gains an *End-to-end import smoke tests (CJS/ESM)* step.

Verified locally: the full gate command runs clean (lint, 94 tests in run mode, e2e 6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)