### PR TITLE
test: harden against silent behavior drift (semantic gap hunt)

### DIFF
--- a/src/hooks/pubsub-integration.spec.ts
+++ b/src/hooks/pubsub-integration.spec.ts
@@ -177,4 +177,39 @@ describe('usePublish + useSubscribe with a custom bus', () => {
     })
     expect(handler).toBeCalledTimes(2) // new bus delivers
   })
+
+  it('usePublish re-routes to the new bus when the bus reference changes', () => {
+    const busA = createPubSub<AppEvents>()
+    const busB = createPubSub<AppEvents>()
+    const handlerA = vi.fn()
+    const handlerB = vi.fn()
+    busA.subscribe('user:login', handlerA)
+    busB.subscribe('user:login', handlerB)
+    let currentBus = busA
+
+    const { result, rerender } = renderHook(() =>
+      usePublish({
+        bus: currentBus,
+        token: 'user:login',
+        message: { userId: '1' },
+      }),
+    )
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+    expect(handlerA).toBeCalledTimes(1)
+    expect(handlerB).toBeCalledTimes(0)
+
+    currentBus = busB
+    rerender()
+
+    act(() => {
+      result.current.publish()
+      vi.advanceTimersByTime(0)
+    })
+    expect(handlerA).toBeCalledTimes(1) // old bus no longer receives
+    expect(handlerB).toBeCalledTimes(1) // new bus receives
+  })
 })

--- a/src/hooks/usePublish.spec.ts
+++ b/src/hooks/usePublish.spec.ts
@@ -210,6 +210,34 @@ describe('usePublish', () => {
     expect(zeroHandler).toHaveBeenCalledWith('zero', 0)
     expect(falseHandler).toHaveBeenCalledWith('flag', false)
   })
+  it('does not publish automatically when message is null', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    renderHook(() => usePublish({ token, message: null, isAutomatic: true }))
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+  })
+  it('does not publish automatically when message is undefined', () => {
+    const handler = vi.fn()
+
+    PubSub.subscribe(token, handler)
+
+    renderHook(() =>
+      usePublish({ token, message: undefined, isAutomatic: true }),
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(301)
+    })
+
+    expect(handler).toBeCalledTimes(0)
+  })
   it('falls back to the default delay when debounceMs is not a number', () => {
     const handler = vi.fn()
 

--- a/src/pubsub/pubsub.spec.ts
+++ b/src/pubsub/pubsub.spec.ts
@@ -92,6 +92,24 @@ describe('internal pub/sub module', () => {
 
       expect(late).toBeCalledTimes(0)
     })
+
+    it('still fires a sibling unsubscribed by an earlier handler during delivery', () => {
+      const bus = createPubSub()
+      const sibling = vi.fn()
+      // The remover is subscribed FIRST so it runs before the sibling and
+      // removes it mid-dispatch. The sibling is still in the publish-time
+      // snapshot, so it must fire anyway.
+      let siblingToken = ''
+      bus.subscribe('t', () => {
+        bus.unsubscribe(siblingToken)
+      })
+      siblingToken = bus.subscribe('t', sibling)
+
+      bus.publish('t', 'm')
+      flush()
+
+      expect(sibling).toBeCalledTimes(1)
+    })
   })
 
   describe('unsubscribe', () => {
@@ -126,6 +144,16 @@ describe('internal pub/sub module', () => {
       bus.publish('b', 'm')
       flush()
       expect(handler).toBeCalledTimes(0)
+    })
+
+    it('returns false on the second by-reference unsubscribe', () => {
+      const bus = createPubSub()
+      const handler = vi.fn()
+      bus.subscribe('a', handler)
+      bus.subscribe('b', handler)
+
+      expect(bus.unsubscribe(handler)).toBe(true) // removed from both channels
+      expect(bus.unsubscribe(handler)).toBe(false) // nothing left to remove
     })
 
     it('unsubscribing an unknown handler returns false', () => {
@@ -229,6 +257,28 @@ describe('internal pub/sub module', () => {
 
       expect(handler).toBeCalledTimes(0)
     })
+
+    it('removes the abort listener from the signal on manual unsubscribe', () => {
+      const bus = createPubSub()
+      const controller = new AbortController()
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener')
+      const off = bus.on('t', vi.fn(), { signal: controller.signal })
+
+      off()
+
+      // No dangling reference left on the signal (prevents an AbortController leak).
+      expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+    })
+
+    it('is safe to abort the signal after a manual unsubscribe', () => {
+      const bus = createPubSub()
+      const controller = new AbortController()
+      const off = bus.on('t', vi.fn(), { signal: controller.signal })
+
+      off()
+
+      expect(() => controller.abort()).not.toThrow()
+    })
   })
 
   describe('subscribeOnce', () => {
@@ -273,6 +323,28 @@ describe('internal pub/sub module', () => {
       flush()
 
       expect(handler).toBeCalledTimes(1) // removed before invoking; not re-fired
+    })
+
+    it('cleans the channel after firing — a later publish reports no subscribers', () => {
+      const bus = createPubSub()
+      bus.subscribeOnce('t', vi.fn())
+
+      bus.publish('t', 'a')
+      flush()
+
+      expect(bus.publish('t', 'b')).toBe(false)
+    })
+
+    it('can be cancelled via its returned token before it fires', () => {
+      const bus = createPubSub()
+      const handler = vi.fn()
+      const token = bus.subscribeOnce('t', handler)
+
+      bus.unsubscribe(token)
+      bus.publish('t', 'm')
+      flush()
+
+      expect(handler).toBeCalledTimes(0)
     })
   })
 
@@ -360,6 +432,17 @@ describe('internal pub/sub module', () => {
       flush()
 
       expect(child).toBeCalledTimes(0)
+    })
+
+    it('walks ancestors for a trailing-dot topic', () => {
+      // Pins targetsFor's dotted-segment parsing: 'a.b.' -> ['a.b.', 'a.b', 'a'].
+      const parent = vi.fn()
+      PubSub.subscribe('a.b', parent)
+
+      PubSub.publish('a.b.', 'm')
+      flush()
+
+      expect(parent).toBeCalledTimes(1)
     })
 
     it('symbols are identity-only on the hierarchical bus (no dotted walk)', () => {

--- a/src/utils/debounce.spec.ts
+++ b/src/utils/debounce.spec.ts
@@ -61,6 +61,19 @@ describe('debounce', () => {
     expect(func).toBeCalledTimes(1)
   })
 
+  it('fires immediately again on a new burst after the cooldown elapses', () => {
+    const func = vi.fn()
+    const debounced = debounce(func, 100, true)
+
+    debounced() // leading edge of the first burst
+    expect(func).toBeCalledTimes(1)
+
+    vi.advanceTimersByTime(100) // cooldown elapses; the internal timeout resets
+
+    debounced() // leading edge of the next burst — fires immediately again
+    expect(func).toBeCalledTimes(2)
+  })
+
   it('clears the timeout', () => {
     const func = vi.fn()
     const debounced = debounce(func, 100)


### PR DESCRIPTION
A subagent gap-hunt over the suite (already 100% line/branch coverage) found behaviors **no test asserts** — places where a refactor could silently change runtime behavior without failing CI. This adds 11 regression tests; findings were independently verified against the source before writing, and the two trickiest are **mutation-verified** (each fails against a plausible wrong implementation).

### Bus (`src/pubsub`)
- by-reference `unsubscribe` returns `false` on the second call
- a sibling unsubscribed by an earlier handler **mid-dispatch still fires** — proves delivery uses the publish-time snapshot, not live-channel iteration · _mutation-verified_
- `subscribeOnce` fully cleans its channel (a later `publish` reports no subscribers)
- `subscribeOnce` is cancellable via its returned token before firing
- `on()`: manual unsubscribe **removes the abort listener from the signal** (no `AbortController` leak) · _mutation-verified_; and aborting after `off()` is safe
- hierarchical: a trailing-dot topic still walks ancestors (`targetsFor` parsing)

### Hooks
- `usePublish` re-routes to the new bus when the `bus` prop changes
- auto-publish skips `null`/`undefined` sentinels (with the existing `0`/`false`/`''` tests, all guarded cases are pinned)

### debounce
- immediate mode fires again on a new burst after the cooldown elapses

Test-only; no `src` changes. 105 tests pass · 100% coverage · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)