### PR TITLE
feat!: drop React 17 support; require React >=18

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ useSubscribe({ bus, token: 'user:login', handler: (_, user) => console.log(user.
 
 ### Migrating from v1 to v2
 
+- The minimum supported React version is now **18.0.0** (was 17). The hooks use
+  only stable React primitives, but React 18+ is required so the library can rely
+  on automatic batching and `useSyncExternalStore`.
 - `pubsub-js` is no longer a dependency; `PubSub` is the library's own bus. If
   you also used `pubsub-js` directly elsewhere you were sharing one global
   singleton — in v2 the bus is independent, so those direct subscribers will no

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "react": ">=17.0.0"
+    "react": ">=18.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.4",


### PR DESCRIPTION
Raises the React peer floor to `>=18.0.0` (was 17).

**Why:** the hooks use only stable primitives, but React 18+ lets the library rely on automatic batching and — for the upcoming `useBusState` hook — **native `useSyncExternalStore`** (no shim). React 17 was also untestable with our current `@testing-library/react` (peer `^18 || ^19`).

- `peerDependencies.react` → `>=18.0.0`
- Migration note added to the README.

The React 18/19 **CI matrix** lands in the dedicated CI-hygiene PR to keep `ci.yml` changes in one place.

BREAKING CHANGE: React 17 is no longer supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)