### PR TITLE
feat!: route subscriber errors to a configurable onError (default console.error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ useSubscribe({ bus, token: 'user:login', handler: (_, user) => console.log(user.
 - Both hooks now accept an optional `bus` param (defaults to the `PubSub`
   singleton), so a `createPubSub<E>()` bus can be driven through the hooks with
   typed payloads.
+- A subscriber that throws no longer re-throws asynchronously (which could crash
+  a Node process). The error now goes to an error handler that defaults to
+  `console.error`; delivery to the other subscribers always continues. Pass your
+  own via `createPubSub({ onError })`.
 - Symbol tokens match by identity (two distinct `Symbol('x')` no longer collide).
 - Removed rarely-used pubsub-js extras (`publishSync`, `subscribeAll`/`*`
   wildcard, `clearSubscriptions(topic)`, `countSubscriptions`,

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -22,7 +22,7 @@ packages:
     resolution: {directory: .., type: directory}
     engines: {node: '>=18'}
     peerDependencies:
-      react: '>=17.0.0'
+      react: '>=18.0.0'
 
 snapshots:
 

--- a/e2e/test.cjs
+++ b/e2e/test.cjs
@@ -29,3 +29,20 @@ test('e2e CJS: PubSub delivers a published message', async () => {
   assert.equal(received[0][0], 'e2e', 'handler receives the token')
   assert.deepEqual(received[0][1], { hi: 1 }, 'handler receives the payload')
 })
+
+test('e2e CJS: a throwing subscriber does not crash the process', async () => {
+  // If delivery re-threw (pre-2.0), the setTimeout throw would be an uncaught
+  // exception and node --test would fail the whole run.
+  const errors = []
+  const bus = createPubSub({ onError: (err) => errors.push(err) })
+  const after = []
+  bus.subscribe('boom', () => {
+    throw new Error('kaboom')
+  })
+  bus.subscribe('boom', () => after.push(1))
+  bus.publish('boom', null)
+  await new Promise((resolve) => setTimeout(resolve, 10))
+
+  assert.equal(after.length, 1, 'other subscribers still run after a throw')
+  assert.equal(errors.length, 1, 'onError received the thrown error')
+})

--- a/e2e/test.cjs
+++ b/e2e/test.cjs
@@ -46,3 +46,24 @@ test('e2e CJS: a throwing subscriber does not crash the process', async () => {
   assert.equal(after.length, 1, 'other subscribers still run after a throw')
   assert.equal(errors.length, 1, 'onError received the thrown error')
 })
+
+test('e2e CJS: a throwing subscriber on the PubSub singleton does not crash', async () => {
+  const originalError = console.error
+  const logged = []
+  console.error = (...args) => logged.push(args)
+  try {
+    const after = []
+    PubSub.subscribe('singleton-boom', () => {
+      throw new Error('kaboom')
+    })
+    PubSub.subscribe('singleton-boom', () => after.push(1))
+    PubSub.publish('singleton-boom', null)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    PubSub.clearAllSubscriptions()
+
+    assert.equal(after.length, 1, 'other singleton subscribers still run')
+    assert.ok(logged.length >= 1, 'default sink (console.error) got the error')
+  } finally {
+    console.error = originalError
+  }
+})

--- a/e2e/test.mjs
+++ b/e2e/test.mjs
@@ -29,3 +29,20 @@ test('e2e ESM: PubSub delivers a published message', async () => {
   assert.equal(received[0][0], 'e2e', 'handler receives the token')
   assert.deepEqual(received[0][1], { hi: 1 }, 'handler receives the payload')
 })
+
+test('e2e ESM: a throwing subscriber does not crash the process', async () => {
+  // If delivery re-threw (pre-2.0), the setTimeout throw would be an uncaught
+  // exception and node --test would fail the whole run.
+  const errors = []
+  const bus = createPubSub({ onError: (err) => errors.push(err) })
+  const after = []
+  bus.subscribe('boom', () => {
+    throw new Error('kaboom')
+  })
+  bus.subscribe('boom', () => after.push(1))
+  bus.publish('boom', null)
+  await new Promise((resolve) => setTimeout(resolve, 10))
+
+  assert.equal(after.length, 1, 'other subscribers still run after a throw')
+  assert.equal(errors.length, 1, 'onError received the thrown error')
+})

--- a/e2e/test.mjs
+++ b/e2e/test.mjs
@@ -46,3 +46,24 @@ test('e2e ESM: a throwing subscriber does not crash the process', async () => {
   assert.equal(after.length, 1, 'other subscribers still run after a throw')
   assert.equal(errors.length, 1, 'onError received the thrown error')
 })
+
+test('e2e ESM: a throwing subscriber on the PubSub singleton does not crash', async () => {
+  const originalError = console.error
+  const logged = []
+  console.error = (...args) => logged.push(args)
+  try {
+    const after = []
+    PubSub.subscribe('singleton-boom', () => {
+      throw new Error('kaboom')
+    })
+    PubSub.subscribe('singleton-boom', () => after.push(1))
+    PubSub.publish('singleton-boom', null)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    PubSub.clearAllSubscriptions()
+
+    assert.equal(after.length, 1, 'other singleton subscribers still run')
+    assert.ok(logged.length >= 1, 'default sink (console.error) got the error')
+  } finally {
+    console.error = originalError
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
 } from './hooks/useSubscribe'
 export { useSubscribe } from './hooks/useSubscribe'
 export type {
+  ErrorHandler,
   EventMap,
   Listener,
   PubSubBus,

--- a/src/pubsub-contract.spec.ts
+++ b/src/pubsub-contract.spec.ts
@@ -91,6 +91,7 @@ describe('PubSub contract', () => {
     flush() // runs delivery; both handlers are invoked despite the throw
 
     expect(after).toBeCalledTimes(1)
+    expect(errSpy).toHaveBeenCalledTimes(1) // the error reached the default sink
     errSpy.mockRestore()
   })
 

--- a/src/pubsub-contract.spec.ts
+++ b/src/pubsub-contract.spec.ts
@@ -76,6 +76,11 @@ describe('PubSub contract', () => {
   })
 
   it('isolates subscriber errors: a throwing handler does not stop the others', () => {
+    // The default singleton routes subscriber errors to console.error; silence
+    // it here so the assertion output stays clean.
+    const errSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
     const after = vi.fn()
     PubSub.subscribe('t', () => {
       throw new Error('boom')
@@ -86,10 +91,7 @@ describe('PubSub contract', () => {
     flush() // runs delivery; both handlers are invoked despite the throw
 
     expect(after).toBeCalledTimes(1)
-    // pubsub-js re-throws a caught handler error via setTimeout(0). Scheduled
-    // *inside* the delivery callback, that nested timer gets callAt=1 under
-    // @sinonjs/fake-timers, so advanceTimersByTime(0) skips it; clearAllTimers()
-    // in afterEach discards it. (We assert isolation, not the async re-throw.)
+    errSpy.mockRestore()
   })
 
   it('preserves order across two publishes in the same tick (A before B)', () => {

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -54,7 +54,24 @@ export interface TypedPubSub<E extends EventMap> {
 
 type AnyListener = Listener<unknown>
 
-const createBus = ({ hierarchical = false } = {}): PubSubBus => {
+/** Invoked when a subscriber throws during delivery. */
+export type ErrorHandler = (error: unknown) => void
+
+const defaultOnError: ErrorHandler = error => {
+  // Surface the error without aborting delivery or crashing the host. The
+  // pre-2.0 behavior re-threw via setTimeout, which terminates a Node process
+  // when no uncaughtException handler is registered; console.error is safe in
+  // both Node and the browser. Pass a custom `onError` to override.
+  console.error('[use-pubsub-js] a subscriber threw during delivery:', error)
+}
+
+const createBus = ({
+  hierarchical = false,
+  onError = defaultOnError,
+}: {
+  hierarchical?: boolean
+  onError?: ErrorHandler
+} = {}): PubSubBus => {
   const channels = new Map<string | symbol, Map<Token, AnyListener>>()
   const tokenToChannel = new Map<Token, string | symbol>()
   let uid = 0
@@ -148,11 +165,10 @@ const createBus = ({ hierarchical = false } = {}): PubSubBus => {
           try {
             handler(token, data)
           } catch (error) {
-            // Isolate: a throwing subscriber must not stop the rest. Re-throw
-            // asynchronously so it surfaces without aborting delivery.
-            setTimeout(() => {
-              throw error
-            }, 0)
+            // Isolate: a throwing subscriber must not stop the rest, and must
+            // not crash the host. Hand the error to onError (default:
+            // console.error) instead of re-throwing.
+            onError(error)
           }
         }
       }
@@ -215,9 +231,19 @@ const createBus = ({ hierarchical = false } = {}): PubSubBus => {
   }
 }
 
-/** Create a flat, typed bus for an event map. */
-export const createPubSub = <E extends EventMap = EventMap>(): TypedPubSub<E> =>
-  createBus({ hierarchical: false }) as unknown as TypedPubSub<E>
+/**
+ * Create a flat, typed bus for an event map.
+ *
+ * @param options.onError - called when a subscriber throws during delivery;
+ * defaults to `console.error`. Delivery to other subscribers always continues.
+ */
+export const createPubSub = <E extends EventMap = EventMap>(options?: {
+  onError?: ErrorHandler
+}): TypedPubSub<E> =>
+  createBus({
+    hierarchical: false,
+    onError: options?.onError,
+  }) as unknown as TypedPubSub<E>
 
 /** The default shared bus: untyped payloads, hierarchical dotted topics. */
 export const PubSub: PubSubBus = createBus({ hierarchical: true })

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -167,8 +167,13 @@ const createBus = ({
           } catch (error) {
             // Isolate: a throwing subscriber must not stop the rest, and must
             // not crash the host. Hand the error to onError (default:
-            // console.error) instead of re-throwing.
-            onError(error)
+            // console.error) instead of re-throwing. Guard onError itself so a
+            // throwing handler can't re-introduce the uncaught-exception crash.
+            try {
+              onError(error)
+            } catch {
+              // onError threw; swallow to preserve delivery isolation.
+            }
           }
         }
       }

--- a/src/pubsub/pubsub.spec.ts
+++ b/src/pubsub/pubsub.spec.ts
@@ -210,18 +210,41 @@ describe('internal pub/sub module', () => {
       expect(onError).toHaveBeenCalledWith(err)
     })
 
-    it('defaults onError to console.error', () => {
+    it('defaults onError to console.error with the thrown error', () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const bus = createPubSub() // no onError → default sink
+      const err = new Error('boom')
       bus.subscribe('t', () => {
-        throw new Error('boom')
+        throw err
       })
 
       bus.publish('t', 'm')
       flush()
 
       expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith(
+        '[use-pubsub-js] a subscriber threw during delivery:',
+        err,
+      )
       spy.mockRestore()
+    })
+
+    it('a throwing onError neither crashes delivery nor stops other subscribers', () => {
+      const after = vi.fn()
+      const bus = createPubSub({
+        onError: () => {
+          throw new Error('onError itself threw')
+        },
+      })
+      bus.subscribe('t', () => {
+        throw new Error('boom')
+      })
+      bus.subscribe('t', after)
+
+      bus.publish('t', 'm')
+
+      expect(() => flush()).not.toThrow()
+      expect(after).toBeCalledTimes(1) // delivery continued past the throwing pair
     })
   })
 

--- a/src/pubsub/pubsub.spec.ts
+++ b/src/pubsub/pubsub.spec.ts
@@ -180,7 +180,7 @@ describe('internal pub/sub module', () => {
 
   describe('error isolation', () => {
     it('a throwing subscriber does not stop the others', () => {
-      const bus = createPubSub()
+      const bus = createPubSub({ onError: () => undefined })
       const after = vi.fn()
       bus.subscribe('t', () => {
         throw new Error('boom')
@@ -188,21 +188,40 @@ describe('internal pub/sub module', () => {
       bus.subscribe('t', after)
 
       bus.publish('t', 'm')
-      flush() // delivery runs; the async re-throw is left pending
+      flush()
 
       expect(after).toBeCalledTimes(1)
     })
 
-    it('re-throws a caught subscriber error asynchronously', () => {
-      const bus = createPubSub()
+    it('routes a subscriber error to onError instead of crashing the host', () => {
+      const onError = vi.fn()
+      const bus = createPubSub({ onError })
+      const err = new Error('boom')
+      bus.subscribe('t', () => {
+        throw err
+      })
+
+      bus.publish('t', 'm')
+
+      // Delivery must never re-throw — flushing the timer is always safe
+      // (the pre-2.0 behavior re-threw and could crash a Node process).
+      expect(() => flush()).not.toThrow()
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith(err)
+    })
+
+    it('defaults onError to console.error', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const bus = createPubSub() // no onError → default sink
       bus.subscribe('t', () => {
         throw new Error('boom')
       })
 
       bus.publish('t', 'm')
+      flush()
 
-      // runAllTimers drains delivery AND the nested re-throw timer
-      expect(() => vi.runAllTimers()).toThrow('boom')
+      expect(spy).toHaveBeenCalledTimes(1)
+      spy.mockRestore()
     })
   })
 
@@ -311,14 +330,14 @@ describe('internal pub/sub module', () => {
     })
 
     it('does not leak the subscription when the handler throws', () => {
-      const bus = createPubSub()
+      const bus = createPubSub({ onError: () => undefined })
       const handler = vi.fn(() => {
         throw new Error('boom')
       })
       bus.subscribeOnce('t', handler)
 
       bus.publish('t', 'a')
-      flush() // handler throws; async re-throw left pending (cleared in afterEach)
+      flush() // handler throws; onError swallows it
       bus.publish('t', 'b')
       flush()
 


### PR DESCRIPTION
**Addresses the security audit's top runtime risk (HIGH).** A throwing subscriber previously re-threw asynchronously via `setTimeout(() => { throw })`, which **terminates a Node host process** when no `uncaughtException` handler is registered (benign in browsers — the asymmetry made it dangerous for SSR/edge/test-runner usage).

- `createBus`/`createPubSub` accept `onError?: (error: unknown) => void`, defaulting to `console.error`. Delivery to other subscribers always continues.
- New exported `ErrorHandler` type.
- Converges with the perf lens (eliminates the per-error timer allocation/nesting clamp).

### Tests
- `onError` is invoked with the error and delivery **never re-throws** (replaces the old re-throw assertion — intentional behavior change).
- defaults to `console.error`; isolation preserved.
- **e2e smoke (CJS + ESM): a throwing subscriber does not crash the process.**
- 106 tests, 100% coverage, lint clean, e2e 8/8.

BREAKING CHANGE: subscriber errors no longer re-throw asynchronously. Restore via `createPubSub({ onError: (e) => { setTimeout(() => { throw e }) } })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)