### PR TITLE
feat!: brand SubscriptionToken so unsubscribe rejects arbitrary strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ useSubscribe({ bus, token: 'user:login', handler: (_, user) => console.log(user.
   a Node process). The error now goes to an error handler that defaults to
   `console.error`; delivery to the other subscribers always continues. Pass your
   own via `createPubSub({ onError })`.
+- `subscribe`/`subscribeOnce` now return a branded `SubscriptionToken` (still a
+  string at runtime). `unsubscribe` only accepts that token or a handler
+  reference, so passing an arbitrary string (e.g. a topic name by mistake) is a
+  type error. The `Token` type is kept as a deprecated alias of
+  `SubscriptionToken`.
 - Symbol tokens match by identity (two distinct `Symbol('x')` no longer collide).
 - Removed rarely-used pubsub-js extras (`publishSync`, `subscribeAll`/`*`
   wildcard, `clearSubscriptions(topic)`, `countSubscriptions`,

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -3,6 +3,7 @@ import {
   type EventMap,
   PubSub,
   type PubSubBus,
+  type SubscriptionToken,
   type TypedPubSub,
 } from '../pubsub'
 
@@ -40,7 +41,7 @@ export const useSubscribe = <
 }: UseSubscribeParams<TokenType, Events>): UseSubscribeResponse => {
   const activeBus = bus as PubSubBus
   const handlerRef = useRef(handler)
-  const subscriptionToken = useRef<string | null>(null)
+  const subscriptionToken = useRef<SubscriptionToken | null>(null)
 
   useEffect(() => {
     handlerRef.current = handler

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
   EventMap,
   Listener,
   PubSubBus,
+  SubscriptionToken,
   Token,
   TypedPubSub,
 } from './pubsub'

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -9,7 +9,19 @@
 // publish time; a throwing subscriber never aborts delivery to the others.
 // Symbol tokens are matched by identity (no stringification, no hierarchy).
 
-export type Token = string
+declare const subscriptionTokenBrand: unique symbol
+
+/**
+ * Opaque handle returned by `subscribe`/`subscribeOnce`. Pass it to
+ * `unsubscribe`. It is a branded `string`, so an arbitrary string (e.g. a topic
+ * name passed by mistake) is rejected at compile time.
+ */
+export type SubscriptionToken = string & {
+  readonly [subscriptionTokenBrand]: typeof subscriptionTokenBrand
+}
+
+/** @deprecated Renamed to {@link SubscriptionToken}. */
+export type Token = SubscriptionToken
 
 export type Listener<T = unknown> = (token: string | symbol, data: T) => void
 
@@ -24,12 +36,17 @@ export interface PubSubBus {
     options?: { signal?: AbortSignal },
   ): () => void
   publish<T = unknown>(token: string | symbol, data?: T): boolean
-  subscribe<T = unknown>(token: string | symbol, handler: Listener<T>): Token
+  subscribe<T = unknown>(
+    token: string | symbol,
+    handler: Listener<T>,
+  ): SubscriptionToken
   subscribeOnce<T = unknown>(
     token: string | symbol,
     handler: Listener<T>,
-  ): Token
-  unsubscribe(value: Token | ((...args: never[]) => unknown)): boolean
+  ): SubscriptionToken
+  unsubscribe(
+    value: SubscriptionToken | ((...args: never[]) => unknown),
+  ): boolean
 }
 
 /** Flat, fully-typed bus created by `createPubSub<EventMap>()`. */
@@ -44,12 +61,14 @@ export interface TypedPubSub<E extends EventMap> {
   subscribe<K extends keyof E>(
     token: K,
     handler: (token: K, data: E[K]) => void,
-  ): Token
+  ): SubscriptionToken
   subscribeOnce<K extends keyof E>(
     token: K,
     handler: (token: K, data: E[K]) => void,
-  ): Token
-  unsubscribe(value: Token | ((...args: never[]) => unknown)): boolean
+  ): SubscriptionToken
+  unsubscribe(
+    value: SubscriptionToken | ((...args: never[]) => unknown),
+  ): boolean
 }
 
 type AnyListener = Listener<unknown>
@@ -80,7 +99,7 @@ const createBus = ({
     token: string | symbol,
     handler: Listener<T>,
   ): Token => {
-    const id = `uid_${uid++}`
+    const id = `uid_${uid++}` as SubscriptionToken
     let channel = channels.get(token)
     if (!channel) {
       channel = new Map()


### PR DESCRIPTION
`subscribe`/`subscribeOnce` now return a **branded `SubscriptionToken`** (a plain string at runtime). `unsubscribe` accepts only that token or a handler reference, so passing an arbitrary string — e.g. a topic name by mistake — is a **compile error**. `Token` is kept as a deprecated alias; the hook's internal token ref is typed accordingly.

### Adjudication: unified `PubSubInterface` dropped
The audit's "unify the two bus interfaces to remove the `as unknown as TypedPubSub` cast" was **empirically tested and does not work**: the loose impl isn't assignable to a strict generic interface (`'BusKey' is not assignable to type 'T'` — generic method variance), and `keyof E` admits `number` which violates the key constraint. It would still need the cast plus extra `keyof` filtering — churn without payoff. So this PR ships the high-value, low-risk half (branding) only.

- Build-enforced (tsdown dts type-checks src); runtime behavior unchanged.
- 107 tests, 100% coverage, lint clean, attw + publint green.

BREAKING CHANGE: `subscribe`/`subscribeOnce` return `SubscriptionToken` (branded) instead of `string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)