### PR TITLE
chore!: bundle/packaging hygiene (drop utils/debounce subpath, es2021 target)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ The default `use-pubsub-js` export is unchanged and stays React-18 compatible.
   `getSubscriptions`, `immediateExceptions`). `publish`, `subscribe`,
   `subscribeOnce`, `unsubscribe`, `clearAllSubscriptions` and hierarchical
   topics are kept.
+- The internal `use-pubsub-js/utils/debounce` subpath is no longer exported (it
+  was undocumented). Use a dedicated debounce utility if you need one.
 
 ## Examples
 

--- a/e2e/test.cjs
+++ b/e2e/test.cjs
@@ -18,6 +18,11 @@ test('e2e CJS: ./pubsub subpath is usable', () => {
   assert.equal(typeof subpathCreatePubSub, 'function', 'subpath createPubSub')
 })
 
+test('e2e CJS: barrel and ./pubsub share one PubSub singleton', () => {
+  // Guards against the exports map accidentally instantiating two singletons.
+  assert.strictEqual(PubSub, subpathPubSub, 'same PubSub instance')
+})
+
 test('e2e CJS: PubSub delivers a published message', async () => {
   const received = []
   PubSub.subscribe('e2e', (token, data) => received.push([token, data]))

--- a/e2e/test.mjs
+++ b/e2e/test.mjs
@@ -18,6 +18,11 @@ test('e2e ESM: ./pubsub subpath is usable', () => {
   assert.equal(typeof subpathCreatePubSub, 'function', 'subpath createPubSub')
 })
 
+test('e2e ESM: barrel and ./pubsub share one PubSub singleton', () => {
+  // Guards against the exports map accidentally instantiating two singletons.
+  assert.strictEqual(PubSub, subpathPubSub, 'same PubSub instance')
+})
+
 test('e2e ESM: PubSub delivers a published message', async () => {
   const received = []
   PubSub.subscribe('e2e', (token, data) => received.push([token, data]))

--- a/package.json
+++ b/package.json
@@ -83,16 +83,6 @@
         "default": "./dist/hooks/react19/useSubscribe.cjs"
       }
     },
-    "./utils/debounce": {
-      "import": {
-        "types": "./dist/utils/debounce.d.ts",
-        "default": "./dist/utils/debounce.js"
-      },
-      "require": {
-        "types": "./dist/utils/debounce.d.cts",
-        "default": "./dist/utils/debounce.cjs"
-      }
-    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -111,9 +101,6 @@
       ],
       "react19/useSubscribe": [
         "./dist/hooks/react19/useSubscribe.d.ts"
-      ],
-      "utils/debounce": [
-        "./dist/utils/debounce.d.ts"
       ]
     }
   },

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -296,5 +296,8 @@ export const createPubSub = <E extends EventMap = EventMap>(options?: {
     onError: options?.onError,
   }) as unknown as TypedPubSub<E>
 
+// The package sets `sideEffects: false`, so a bundler may tree-shake this
+// singleton for consumers that only import `createPubSub`. (A `/*#__PURE__*/`
+// annotation here is stripped by minification, so it would be a no-op.)
 /** The default shared bus: untyped payloads, hierarchical dotted topics. */
 export const PubSub: PubSubBus = createBus({ hierarchical: true })

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -58,6 +58,3 @@ export function debounce<T extends (...args: any[]) => any>(
 
   return debounced
 }
-
-// Adds compatibility for ES modules
-debounce.debounce = debounce

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -9,4 +9,6 @@ export default defineConfig({
   unbundle: true,
   minify: true,
   platform: 'browser',
+  // Explicit ES target (this is a browser library), independent of engines.node.
+  target: 'es2021',
 })


### PR DESCRIPTION
From the bundle/distribution audit (verified):

- Remove the vestigial `debounce.debounce = debounce` self-assignment — a real module-level side effect that contradicted `sideEffects: false`.
- **Drop the undocumented `./utils/debounce` public subpath** (+ typesVersions). debounce stays internal to `usePublish`.
- tsdown: explicit `target: 'es2021'` (browser library; was inferred from `engines.node` and read confusingly as `node18`).
- e2e: **dual-package identity guard** — the barrel `PubSub` and the `./pubsub` subpath must be the same singleton within a module system.
- Documented why `/*#__PURE__*/` isn't used (minification strips it; `sideEffects: false` is the effective tree-shaking mechanism).

125 tests, 100% coverage, lint clean, e2e 12/12, attw "No problems found 🌟" + publint clean.

BREAKING CHANGE: `use-pubsub-js/utils/debounce` is no longer exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)