### PR TITLE
perf(pubsub): flatten the publish snapshot to one array

### DIFF
--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -183,33 +183,35 @@ const createBus = ({
     // independent of whether anyone is currently subscribed.
     lastValues?.set(token, data)
     const targets = targetsFor(token)
-    // Snapshot every target level synchronously, before scheduling delivery,
-    // so subscribe/unsubscribe during the wait can't corrupt this dispatch.
-    const snapshots: AnyListener[][] = []
+    // Snapshot subscribers synchronously, before scheduling delivery, so
+    // subscribe/unsubscribe during the wait can't corrupt this dispatch. One
+    // flat array preserves delivery order (exact topic first, then ancestors;
+    // subscription order within each) while avoiding an array-per-level alloc.
+    const snapshot: AnyListener[] = []
     for (const target of targets) {
       const channel = channels.get(target)
-      if (channel && channel.size > 0) {
-        snapshots.push([...channel.values()])
+      if (channel) {
+        for (const handler of channel.values()) {
+          snapshot.push(handler)
+        }
       }
     }
-    if (snapshots.length === 0) {
+    if (snapshot.length === 0) {
       return false
     }
     setTimeout(() => {
-      for (const handlers of snapshots) {
-        for (const handler of handlers) {
+      for (const handler of snapshot) {
+        try {
+          handler(token, data)
+        } catch (error) {
+          // Isolate: a throwing subscriber must not stop the rest, and must not
+          // crash the host. Hand the error to onError (default: console.error)
+          // instead of re-throwing. Guard onError itself so a throwing handler
+          // can't re-introduce the uncaught-exception crash.
           try {
-            handler(token, data)
-          } catch (error) {
-            // Isolate: a throwing subscriber must not stop the rest, and must
-            // not crash the host. Hand the error to onError (default:
-            // console.error) instead of re-throwing. Guard onError itself so a
-            // throwing handler can't re-introduce the uncaught-exception crash.
-            try {
-              onError(error)
-            } catch {
-              // onError threw; swallow to preserve delivery isolation.
-            }
+            onError(error)
+          } catch {
+            // onError threw; swallow to preserve delivery isolation.
           }
         }
       }


### PR DESCRIPTION
Replace the array-of-arrays snapshot (one array per hierarchy level) with a single flat array built by direct push — cuts allocations from O(levels) arrays to one per publish (most impactful for hierarchical topics) and flattens the delivery loop.

**Delivery order is unchanged** (exact topic first, then ancestors, subscription order within each) and guarded by the existing order tests. **Mutation-verified:** reversing the snapshot fails 4 order tests.

The other perf-audit ideas were deliberately left out (adjudicated):
- *stable debounce instance* — subtly changes the `isImmediate`+automatic rapid-message behavior (current code fires immediately on every message change; a stable instance wouldn't).
- *drop useMemo on hook returns* — touches hook return identity for memo'd consumers.

Neither is worth the tiny allocation savings.

No API/behavior change. 125 tests, 100% coverage, lint clean, e2e 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)