### PR TITLE
docs: TSDoc on the public API, "Choosing a bus" guide, typed-bus demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ You can import the hooks or a service to use where you want
 import { PubSub, usePublish, useSubscribe } from 'use-pubsub-js'
 ```
 
+### Choosing a bus
+
+There are two buses, and picking the right one up front avoids the most common
+gotcha:
+
+- **`PubSub`** — the shared singleton. Untyped payloads, **hierarchical** string
+  topics (publishing `a.b.c` also notifies `a.b` and `a`). Use it for quick,
+  app-wide messaging. The hooks use it by default.
+- **`createPubSub<Events>()`** — an independent, **flat, fully-typed** bus. Use it
+  when you want TypeScript-checked payloads per topic. It is a **separate
+  instance**, so wire it into the hooks via their `bus` param everywhere you use
+  it (otherwise the hooks stay on the singleton and won't see its messages).
+
 ### useSubscribe
 ```tsx
 import { PubSub, useSubscribe } from 'use-pubsub-js'
@@ -270,13 +283,10 @@ The default `use-pubsub-js` export is unchanged and stays React-18 compatible.
 
 ## Examples
 
-**Checkout the simple examples on [Example folder](https://github.com/reactivando/use-pubsub-js/blob/main/example/src/App.tsx)**
-
-or
-
-More real examples:
-
-[![Edit use-pubsub-js](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/use-pubsub-js-ei2ly?fontsize=14&hidenavigation=1&theme=dark)
+See the runnable demo in the
+[example folder](https://github.com/reactivando/use-pubsub-js/blob/main/example/src/App.tsx),
+which covers manual/automatic publishing, external messages, and a typed bus
+driven through the hooks.
 
 ## API Documentation
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,11 +1,21 @@
 import { useState } from 'react'
-import { usePublish, useSubscribe } from 'use-pubsub-js'
+import {
+  createPubSub,
+  useBusState,
+  usePublish,
+  useSubscribe,
+} from 'use-pubsub-js'
 
 import { Token, TokenFour, TokenThree, TokenTwo } from './service/constants'
 import { PublishService } from './service/publish'
 
 PublishService.publish(Token)
 PublishService.publish(TokenTwo)
+
+// A typed, retained bus driven through the hooks (the v2 headline feature).
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be a type alias, not an interface — createPubSub<E extends EventMap> needs the implicit index signature interfaces lack
+type TypedEvents = { 'counter:set': number }
+const typedBus = createPubSub<TypedEvents>({ retained: true })
 
 const ManualExternalMessages = () => {
   const [subscriptionCounter, setSubscriptionCounter] = useState(0)
@@ -136,6 +146,58 @@ const FailPublish = () => {
   )
 }
 
+const TypedPublish = () => {
+  const [count, setCount] = useState(0)
+
+  // `message` is type-checked as number (from TypedEvents['counter:set']).
+  usePublish({
+    bus: typedBus,
+    token: 'counter:set',
+    message: count,
+    isAutomatic: true,
+  })
+
+  return (
+    <button onClick={() => setCount(c => c + 1)} type="button">
+      Increment typed counter
+    </button>
+  )
+}
+
+const TypedReceiveViaSubscribe = () => {
+  const [value, setValue] = useState(0)
+
+  // `received` is inferred as number — no cast.
+  useSubscribe({
+    bus: typedBus,
+    token: 'counter:set',
+    handler: (_token, received) => setValue(received),
+  })
+
+  return (
+    <div>
+      <h2>Typed counter (useSubscribe):</h2>
+      <p>{value}</p>
+    </div>
+  )
+}
+
+const TypedReceiveViaBusState = () => {
+  // Reads the latest value as state — available on mount from the retained bus.
+  const count = useBusState({
+    bus: typedBus,
+    token: 'counter:set',
+    initialValue: 0,
+  })
+
+  return (
+    <div>
+      <h2>Typed counter (useBusState):</h2>
+      <p>{count}</p>
+    </div>
+  )
+}
+
 const App = () => (
   <div className="app">
     <div>
@@ -156,6 +218,12 @@ const App = () => (
     <div>
       <h1>Fail section</h1>
       <FailPublish />
+    </div>
+    <div>
+      <h1>Typed bus section</h1>
+      <TypedReceiveViaSubscribe />
+      <TypedReceiveViaBusState />
+      <TypedPublish />
     </div>
   </div>
 )

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -8,7 +8,9 @@ import {
 import { debounce } from '../utils/debounce'
 
 export interface UsePublishResponse {
+  /** `true` if the most recent publish reached at least one subscriber. */
   lastPublish: boolean
+  /** Publish the current `message` to `token` on demand. */
   publish: () => void
 }
 
@@ -22,14 +24,30 @@ export interface UsePublishParams<
    * stable (e.g. module scope) — changing it re-creates the publisher.
    */
   bus?: PubSubBus | TypedPubSub<Events>
+  /** Debounce window (ms) for automatic publishing. Default `300`. */
   debounceMs?: number | string
+  /** Re-publish automatically whenever `message` changes. Default `false`. */
   isAutomatic?: boolean
+  /** With `isAutomatic`, publish on the leading edge (no debounce delay). */
   isImmediate?: boolean
+  /** Publish once on mount. Default `false`. */
   isInitialPublish?: boolean
+  /** Payload to publish; typed per-token when a typed bus is used. */
   message: TokenType extends keyof Events ? Events[TokenType] : unknown
+  /** Topic to publish to. */
   token: TokenType
 }
 
+/**
+ * Publish messages to a pub/sub topic from a component.
+ *
+ * @example
+ * ```tsx
+ * const { publish, lastPublish } = usePublish({ token: 'cart:add', message: item })
+ * // automatic: re-publishes (debounced) whenever `message` changes
+ * usePublish({ token: 'search', message: query, isAutomatic: true })
+ * ```
+ */
 export const usePublish = <
   TokenType extends string | symbol,
   Events extends EventMap = EventMap,

--- a/src/hooks/useSubscribe.ts
+++ b/src/hooks/useSubscribe.ts
@@ -8,7 +8,9 @@ import {
 } from '../pubsub'
 
 export interface UseSubscribeResponse {
+  /** Re-subscribe `handler` to `token` (no-op if already subscribed). */
   resubscribe: () => void
+  /** Unsubscribe `handler` from `token`. */
   unsubscribe: () => void
 }
 
@@ -22,14 +24,26 @@ export interface UseSubscribeParams<
    * stable (e.g. module scope) — changing it re-subscribes.
    */
   bus?: PubSubBus | TypedPubSub<Events>
+  /** Called on each publish to `token`; the message is typed per-token when a typed bus is used. */
   handler: (
     token: TokenType,
     message: TokenType extends keyof Events ? Events[TokenType] : unknown,
   ) => void
+  /** When `true`, stay unsubscribed; toggle to subscribe/unsubscribe reactively. Default `false`. */
   isUnsubscribe?: boolean
+  /** Topic to subscribe to. */
   token: TokenType
 }
 
+/**
+ * Subscribe a handler to a pub/sub topic for the component's lifetime. The
+ * latest `handler` is always invoked without re-subscribing.
+ *
+ * @example
+ * ```tsx
+ * useSubscribe({ token: 'cart:add', handler: (_, item) => addToCart(item) })
+ * ```
+ */
 export const useSubscribe = <
   TokenType extends string | symbol,
   Events extends EventMap = EventMap,

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -29,26 +29,38 @@ export type EventMap = Record<string | symbol, unknown>
 
 /** Untyped, optionally-hierarchical bus (the `PubSub` singleton shape). */
 export interface PubSubBus {
+  /** Remove every subscription (and retained values, if any). */
   clearAllSubscriptions(): void
   /**
    * The last value published to `token`, or `undefined`. Only retains values
    * when the bus was created with `{ retained: true }` (powers `useBusState`).
    */
   getSnapshot<T = unknown>(token: string | symbol): T | undefined
+  /**
+   * Subscribe and get back a cleanup function (preferred for new code). Pass an
+   * `AbortSignal` to auto-unsubscribe when it aborts.
+   */
   on<T = unknown>(
     token: string | symbol,
     handler: Listener<T>,
     options?: { signal?: AbortSignal },
   ): () => void
+  /**
+   * Publish `data` to `token`. Delivery is async; returns `true` if at least one
+   * subscriber was registered at publish time, `false` otherwise.
+   */
   publish<T = unknown>(token: string | symbol, data?: T): boolean
+  /** Subscribe and get back a token to pass to {@link PubSubBus.unsubscribe}. */
   subscribe<T = unknown>(
     token: string | symbol,
     handler: Listener<T>,
   ): SubscriptionToken
+  /** Subscribe for a single delivery, then auto-unsubscribe. */
   subscribeOnce<T = unknown>(
     token: string | symbol,
     handler: Listener<T>,
   ): SubscriptionToken
+  /** Unsubscribe by the token from `subscribe`/`subscribeOnce`, or by handler reference. */
   unsubscribe(
     value: SubscriptionToken | ((...args: never[]) => unknown),
   ): boolean


### PR DESCRIPTION
From the DX audit — make v2's value discoverable without leaving the editor.

- **TSDoc** on `usePublish`/`useSubscribe` (params + `@example`) and the `PubSubBus` methods (the `subscribe`-vs-`on` distinction, `publish` return semantics, etc.). Verified the comments land in the published `.d.ts`, so IDE hover now documents the API.
- **README:** a "Choosing a bus" section up top (`PubSub` singleton vs `createPubSub` typed bus — the #1 first-run gotcha); replaced the stale v1 CodeSandbox link with the example folder.
- **Demo:** a "Typed bus section" showcasing `createPubSub<Events>({ retained: true })` driven through `usePublish`/`useSubscribe` (typed payloads) and `useBusState` — the v2 headline feature, which the demo previously didn't show.

Docs/example only; no library behavior change. 125 tests, 100% coverage, lint clean, lib + example build, e2e 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)