### PR TITLE
test: harden the v2 surface — property tests + gap-hunt regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@vitest/coverage-v8": "^4.1.9",
+    "fast-check": "^4.8.0",
     "jsdom": "^29.1.1",
     "lefthook": "^2.1.9",
     "publint": "^0.3.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -1465,6 +1468,10 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
@@ -2169,6 +2176,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -4007,6 +4017,10 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-content-type-parse@3.0.0: {}
 
   fast-string-truncated-width@3.0.3: {}
@@ -4686,6 +4700,8 @@ snapshots:
       sade: 1.8.1
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   quansync@1.0.0: {}
 

--- a/src/hooks/react19/useSubscribe.spec.ts
+++ b/src/hooks/react19/useSubscribe.spec.ts
@@ -133,5 +133,60 @@ describe.skipIf(!hasEffectEvent)(
 
       expect(handler).toBeCalledTimes(0)
     })
+
+    it('routes messages for a Symbol token', () => {
+      const symbolToken = Symbol('event')
+      const handler = vi.fn()
+      renderHook(() => useSubscribe({ token: symbolToken, handler }))
+
+      act(() => {
+        PubSub.publish(symbolToken, 'payload')
+        vi.advanceTimersByTime(0)
+      })
+
+      expect(handler).toBeCalledTimes(1)
+      expect(handler.mock.calls[0][1]).toBe('payload')
+    })
+
+    it('delivers to multiple independent subscribers and by reference', () => {
+      const handler1 = vi.fn()
+      const handler2 = vi.fn()
+      const payload = { nested: 1 }
+      renderHook(() => useSubscribe({ token, handler: handler1 }))
+      renderHook(() => useSubscribe({ token, handler: handler2 }))
+
+      act(() => {
+        PubSub.publish(token, payload)
+        vi.advanceTimersByTime(0)
+      })
+
+      expect(handler1).toBeCalledTimes(1)
+      expect(handler2).toBeCalledTimes(1)
+      expect(handler1.mock.calls[0][1]).toBe(payload) // same reference, not cloned
+    })
+
+    it('resubscribes when isUnsubscribe is toggled back to false', () => {
+      const handler = vi.fn()
+      let isUnsubscribe = true
+
+      const { rerender } = renderHook(() =>
+        useSubscribe({ token, handler, isUnsubscribe }),
+      )
+
+      act(() => {
+        publish()
+        vi.advanceTimersByTime(0)
+      })
+      expect(handler).toBeCalledTimes(0)
+
+      isUnsubscribe = false
+      rerender()
+
+      act(() => {
+        publish()
+        vi.advanceTimersByTime(0)
+      })
+      expect(handler).toBeCalledTimes(1)
+    })
   },
 )

--- a/src/hooks/useBusState.spec.ts
+++ b/src/hooks/useBusState.spec.ts
@@ -118,6 +118,57 @@ describe('useBusState', () => {
     expect(result.current).toBe(0)
   })
 
+  it('reads the new token snapshot when the token prop changes on a retained bus', () => {
+    const bus = createPubSub<{ a: number; b: number }>({ retained: true })
+    bus.publish('a', 10)
+    bus.publish('b', 99)
+
+    let currentToken: 'a' | 'b' = 'a'
+    const { result, rerender } = renderHook(() =>
+      useBusState({ bus, token: currentToken, initialValue: 0 }),
+    )
+    expect(result.current).toBe(10)
+
+    currentToken = 'b'
+    rerender()
+
+    expect(result.current).toBe(99) // immediately reads retained 'b', not 0 or 10
+  })
+
+  it('ignores an undefined payload (keeps the prior value)', () => {
+    const bus = createPubSub<{ x: number | undefined }>({ retained: true })
+    const { result } = renderHook(() =>
+      useBusState({ bus, token: 'x', initialValue: 0 }),
+    )
+
+    act(() => {
+      bus.publish('x', 42)
+      vi.advanceTimersByTime(0)
+    })
+    expect(result.current).toBe(42)
+
+    act(() => {
+      bus.publish('x', undefined)
+      vi.advanceTimersByTime(0)
+    })
+    expect(result.current).toBe(42) // undefined is treated as "no value"
+  })
+
+  it('reflects only the last value when publishes arrive in the same tick', () => {
+    const bus = createPubSub<{ count: number }>({ retained: true })
+    const { result } = renderHook(() =>
+      useBusState({ bus, token: 'count', initialValue: 0 }),
+    )
+
+    act(() => {
+      bus.publish('count', 1)
+      bus.publish('count', 2)
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(result.current).toBe(2)
+  })
+
   it('renders the server snapshot (initial value) during SSR', () => {
     const bus = createPubSub<{ count: number }>({ retained: true })
     bus.publish('count', 99) // retained, but SSR must use the server snapshot

--- a/src/hooks/useBusState.ts
+++ b/src/hooks/useBusState.ts
@@ -62,6 +62,11 @@ export const useBusState = <
   const subscribe = useCallback(
     (onStoreChange: () => void) =>
       activeBus.on(token, (_deliveredToken, data) => {
+        // Treat an `undefined` payload as "no value": keep the prior value /
+        // initialValue rather than blanking the displayed state.
+        if (data === undefined) {
+          return
+        }
         latestRef.current = { bus: activeBus, token, value: data as Value }
         onStoreChange()
       }),

--- a/src/pubsub/pubsub.property.spec.ts
+++ b/src/pubsub/pubsub.property.spec.ts
@@ -1,0 +1,135 @@
+import fc from 'fast-check'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPubSub } from './index'
+
+// Property-based invariants for the flat bus. Delivery is async (setTimeout(0)),
+// so fake timers make each publish deterministic via advanceTimersByTime(0).
+const flush = () => vi.advanceTimersByTime(0)
+const silent = () => createPubSub({ onError: () => undefined })
+
+describe('PubSub property-based invariants', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('delivers a publish to exactly the handlers subscribed to that token', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string(), { maxLength: 8 }),
+        fc.string(),
+        (tokens, published) => {
+          const bus = silent()
+          const calls = tokens.map(() => 0)
+          tokens.forEach((t, i) => {
+            bus.subscribe(t, () => {
+              calls[i]++
+            })
+          })
+
+          bus.publish(published, null)
+          flush()
+
+          // Each distinct handler fires exactly once iff its token matches the
+          // published token (flat bus: exact-match only, no hierarchy).
+          tokens.forEach((t, i) => {
+            expect(calls[i]).toBe(t === published ? 1 : 0)
+          })
+        },
+      ),
+    )
+  })
+
+  it('never delivers to a handler after it is unsubscribed by token', () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.integer({ min: 1, max: 6 }),
+        (token, publishes) => {
+          const bus = silent()
+          const handler = vi.fn()
+          const id = bus.subscribe(token, handler)
+          bus.unsubscribe(id)
+
+          for (let n = 0; n < publishes; n++) {
+            bus.publish(token, n)
+          }
+          flush()
+
+          expect(handler).not.toHaveBeenCalled()
+        },
+      ),
+    )
+  })
+
+  it('fires subscribeOnce at most once regardless of publish count', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 8 }), publishes => {
+        const bus = silent()
+        const handler = vi.fn()
+        bus.subscribeOnce('t', handler)
+
+        for (let n = 0; n < publishes; n++) {
+          bus.publish('t', n)
+          flush()
+        }
+
+        expect(handler).toHaveBeenCalledTimes(1)
+      }),
+    )
+  })
+
+  it('routes adversarial token strings only to their own subscribers, with no prototype pollution', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          '__proto__',
+          'constructor',
+          'prototype',
+          'toString',
+          'hasOwnProperty',
+          'a.b.c',
+          '',
+          '.',
+        ),
+        token => {
+          const bus = silent()
+          const own = vi.fn()
+          const other = vi.fn()
+          bus.subscribe(token, own)
+          bus.subscribe('unrelated', other)
+
+          bus.publish(token, 1)
+          flush()
+
+          expect(own).toHaveBeenCalledTimes(1)
+          expect(other).not.toHaveBeenCalled()
+          // Map-based storage must never touch Object.prototype.
+          expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+          expect(
+            (Object.prototype as Record<string, unknown>).polluted,
+          ).toBeUndefined()
+        },
+      ),
+    )
+  })
+
+  it('retains the most recent value per token (getSnapshot)', () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.array(fc.integer(), { minLength: 1, maxLength: 6 }),
+        (token, values) => {
+          const bus = createPubSub<Record<string, number>>({ retained: true })
+          for (const v of values) {
+            bus.publish(token, v)
+          }
+          expect(bus.getSnapshot(token)).toBe(values.at(-1))
+        },
+      ),
+    )
+  })
+})

--- a/src/pubsub/pubsub.spec.ts
+++ b/src/pubsub/pubsub.spec.ts
@@ -246,6 +246,27 @@ describe('internal pub/sub module', () => {
       expect(() => flush()).not.toThrow()
       expect(after).toBeCalledTimes(1) // delivery continued past the throwing pair
     })
+
+    it('calls onError once per throwing subscriber (N throwers → N calls)', () => {
+      const onError = vi.fn()
+      const bus = createPubSub({ onError })
+      const after = vi.fn()
+      bus.subscribe('t', () => {
+        throw new Error('first')
+      })
+      bus.subscribe('t', () => {
+        throw new Error('second')
+      })
+      bus.subscribe('t', after)
+
+      bus.publish('t', 'm')
+      flush()
+
+      expect(onError).toHaveBeenCalledTimes(2)
+      expect(onError.mock.calls[0][0]).toMatchObject({ message: 'first' })
+      expect(onError.mock.calls[1][0]).toMatchObject({ message: 'second' })
+      expect(after).toBeCalledTimes(1)
+    })
   })
 
   describe('on() / AbortSignal', () => {
@@ -367,6 +388,21 @@ describe('internal pub/sub module', () => {
       expect(handler).toBeCalledTimes(1) // removed before invoking; not re-fired
     })
 
+    it('routes a throwing once-handler through onError exactly once', () => {
+      const onError = vi.fn()
+      const bus = createPubSub({ onError })
+      bus.subscribeOnce('t', () => {
+        throw new Error('once-boom')
+      })
+
+      bus.publish('t', 'a')
+      expect(() => flush()).not.toThrow()
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError.mock.calls[0][0]).toMatchObject({ message: 'once-boom' })
+      expect(bus.publish('t', 'b')).toBe(false) // already removed before the throw
+    })
+
     it('cleans the channel after firing — a later publish reports no subscribers', () => {
       const bus = createPubSub()
       bus.subscribeOnce('t', vi.fn())
@@ -434,6 +470,32 @@ describe('internal pub/sub module', () => {
       bus.publish('t', 'x')
       bus.clearAllSubscriptions()
       expect(bus.getSnapshot('t')).toBeUndefined()
+    })
+
+    it('retains per exact token — no spill to dotted ancestors (flat bus)', () => {
+      const bus = createPubSub({ retained: true })
+      bus.publish('a.b.c', 'val')
+
+      expect(bus.getSnapshot('a.b.c')).toBe('val')
+      expect(bus.getSnapshot('a.b')).toBeUndefined()
+      expect(bus.getSnapshot('a')).toBeUndefined()
+    })
+
+    it('retains and returns a symbol-keyed value via getSnapshot', () => {
+      const bus = createPubSub({ retained: true })
+      const sym = Symbol('evt')
+      bus.publish(sym, { n: 7 })
+
+      expect(bus.getSnapshot(sym)).toEqual({ n: 7 })
+    })
+
+    it('stores an explicitly published undefined (indistinguishable from unpublished)', () => {
+      const bus = createPubSub({ retained: true })
+      bus.publish('t', 'initial')
+      expect(bus.getSnapshot('t')).toBe('initial')
+
+      bus.publish('t', undefined)
+      expect(bus.getSnapshot('t')).toBeUndefined() // prior value is clobbered
     })
   })
 


### PR DESCRIPTION
You asked for more tests on the new v2 surface — here they are, from property-based testing + a subagent gap-hunt (each gap independently verified).

**Property-based (fast-check) on the bus:** delivery routes only to a token's own subscribers; unsubscribed handlers never fire; `subscribeOnce` fires ≤1×; adversarial tokens (`__proto__`, `constructor`, `.`, `''`) route correctly with **no prototype pollution**; retained `getSnapshot` returns the latest value.

**Gap-hunt regressions:**
- `onError` once **per** throwing subscriber (N→N); throwing `subscribeOnce` → `onError` once, not leaked.
- retained: per-exact-token (no spill to dotted ancestors), symbol-keyed, explicit-`undefined` clobbers prior.
- `useBusState`: token change on a retained bus reads the new token; **`undefined` payload now ignored** (small fix so the code matches its documented "keeps prior value" contract); same-tick publishes show only the last value.
- react19/useSubscribe parity: symbol token, multiple subscribers + by-reference payload, `isUnsubscribe` toggle-back.

> Deliberately skipped the gap-hunt's *publish-then-unmount-before-delivery* cases — the publish snapshots subscribers synchronously, so the handler fires from the snapshot regardless (bus-level behavior, already tested there). Asserting otherwise would be wrong.

devDep: `fast-check`. **141 tests, 100% coverage**, lint clean, e2e 12/12, attw 🌟 + publint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)