### PR TITLE
feat: createHierarchicalPubSub<E> — typed + hierarchical bus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       if: matrix.react == '19'
       run: pnpm lint
 
+    - name: Type-level tests
+      if: matrix.react == '19'
+      run: pnpm test:types
+
     - name: Build library and example
       if: matrix.react == '19'
       run: |

--- a/README.md
+++ b/README.md
@@ -195,6 +195,35 @@ useSubscribe({ bus, token: 'user:login', handler: (_, user) => console.log(user.
 > leave it as the default) to use the shared `PubSub` singleton. Keep the `bus`
 > reference stable (e.g. module scope) — changing it re-subscribes/re-publishes.
 
+### Typed **and** hierarchical: `createHierarchicalPubSub`
+
+`createPubSub` is flat (exact-key); the `PubSub` singleton is hierarchical but
+untyped. `createHierarchicalPubSub<Events>()` gives you both — typed payloads on
+a dotted-topic tree, where publishing `order.created` also notifies `order`:
+
+```ts
+import { createHierarchicalPubSub } from 'use-pubsub-js'
+
+const bus = createHierarchicalPubSub<{
+  order: { id: string }
+  'order.created': { id: string; total: number }
+}>()
+
+bus.subscribe('order', (token, data) => {
+  // token: 'order' | 'order.created'  (the precise descendant union)
+  // data is the union of those payloads — narrow it with a property check:
+  if ('total' in data) {
+    console.log(data.total)
+  }
+})
+
+bus.publish('order.created', { id: '1', total: 9 }) // also notifies 'order'
+```
+
+Two things to know: a handler's `data` is narrowed by a **property check**, not
+by `token` (TypeScript can't correlate the two parameters); and you can only
+publish/subscribe **declared** keys.
+
 ### `useBusState` — read the latest value as state
 
 `useBusState` returns a topic's most recent value as React state (backed by

--- a/e2e/test.cjs
+++ b/e2e/test.cjs
@@ -1,6 +1,13 @@
 const assert = require('node:assert')
 const test = require('node:test')
-const { PubSub, createPubSub, useSubscribe, usePublish } = require('use-pubsub-js')
+const {
+  PubSub,
+  createPubSub,
+  createHierarchicalPubSub,
+  useBusState,
+  useSubscribe,
+  usePublish,
+} = require('use-pubsub-js')
 const {
   PubSub: subpathPubSub,
   createPubSub: subpathCreatePubSub,
@@ -9,6 +16,12 @@ const {
 test('e2e CJS: public named exports are present', () => {
   assert.notEqual(PubSub, undefined, 'PubSub should be defined')
   assert.equal(typeof createPubSub, 'function', 'createPubSub should be a function')
+  assert.equal(
+    typeof createHierarchicalPubSub,
+    'function',
+    'createHierarchicalPubSub should be a function',
+  )
+  assert.equal(typeof useBusState, 'function', 'useBusState should be a function')
   assert.equal(typeof useSubscribe, 'function', 'useSubscribe should be a function')
   assert.equal(typeof usePublish, 'function', 'usePublish should be a function')
 })

--- a/e2e/test.mjs
+++ b/e2e/test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert'
 import test from 'node:test'
-import { createPubSub, PubSub, usePublish, useSubscribe } from 'use-pubsub-js'
+import {
+  createHierarchicalPubSub,
+  createPubSub,
+  PubSub,
+  useBusState,
+  usePublish,
+  useSubscribe,
+} from 'use-pubsub-js'
 import {
   createPubSub as subpathCreatePubSub,
   PubSub as subpathPubSub,
@@ -9,6 +16,12 @@ import {
 test('e2e ESM: public named exports are present', () => {
   assert.notEqual(PubSub, undefined, 'PubSub should be defined')
   assert.equal(typeof createPubSub, 'function', 'createPubSub should be a function')
+  assert.equal(
+    typeof createHierarchicalPubSub,
+    'function',
+    'createHierarchicalPubSub should be a function',
+  )
+  assert.equal(typeof useBusState, 'function', 'useBusState should be a function')
   assert.equal(typeof useSubscribe, 'function', 'useSubscribe should be a function')
   assert.equal(typeof usePublish, 'function', 'usePublish should be a function')
 })

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "build": "tsdown",
     "format": "ultracite fix ./src",
     "lint": "ultracite check ./src",
+    "test:types": "vitest --run --typecheck.only",
     "size": "size-limit",
     "prepare": "lefthook install",
     "test:e2e": "pnpm build && cd e2e && pnpm install --ignore-workspace && pnpm test",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -6,7 +6,9 @@ describe('package entry (src/index)', () => {
   it('exposes the named public API', () => {
     expect(typeof api.usePublish).toBe('function')
     expect(typeof api.useSubscribe).toBe('function')
+    expect(typeof api.useBusState).toBe('function')
     expect(typeof api.createPubSub).toBe('function')
+    expect(typeof api.createHierarchicalPubSub).toBe('function')
     expect(api.PubSub).toBeDefined()
     expect(typeof api.PubSub.subscribe).toBe('function')
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,18 @@ export type {
 } from './hooks/useSubscribe'
 export { useSubscribe } from './hooks/useSubscribe'
 export type {
+  DescendantKey,
   ErrorHandler,
   EventMap,
+  HierarchicalPubSub,
   Listener,
   PubSubBus,
   SubscriptionToken,
   Token,
   TypedPubSub,
 } from './pubsub'
-export { createPubSub, PubSub } from './pubsub'
+export {
+  createHierarchicalPubSub,
+  createPubSub,
+  PubSub,
+} from './pubsub'

--- a/src/pubsub/hierarchical.spec.ts
+++ b/src/pubsub/hierarchical.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHierarchicalPubSub } from './index'
+
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be a type alias — createHierarchicalPubSub<E extends EventMap> needs the implicit index signature interfaces lack
+type Events = {
+  order: { id: string }
+  'order.created': { id: string; total: number }
+}
+
+const flush = () => vi.advanceTimersByTime(0)
+
+describe('createHierarchicalPubSub', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('notifies the exact topic then each ancestor, with the published token', () => {
+    const bus = createHierarchicalPubSub<Events>()
+    const order: string[] = []
+    const seen: string[] = []
+    bus.subscribe('order.created', t => {
+      order.push('order.created')
+      seen.push(t as string)
+    })
+    bus.subscribe('order', t => {
+      order.push('order')
+      seen.push(t as string)
+    })
+
+    bus.publish('order.created', { id: '1', total: 9 })
+    flush()
+
+    expect(order).toEqual(['order.created', 'order'])
+    expect(seen).toEqual(['order.created', 'order.created']) // original token
+  })
+
+  it('does not notify descendants when publishing a parent', () => {
+    const bus = createHierarchicalPubSub<Events>()
+    const child = vi.fn()
+    bus.subscribe('order.created', child)
+
+    bus.publish('order', { id: '1' })
+    flush()
+
+    expect(child).toBeCalledTimes(0)
+  })
+
+  it('delivers the published payload to ancestor subscribers', () => {
+    const bus = createHierarchicalPubSub<Events>()
+    const handler = vi.fn()
+    bus.subscribe('order', handler)
+
+    bus.publish('order.created', { id: '1', total: 9 })
+    flush()
+
+    expect(handler.mock.calls[0][1]).toEqual({ id: '1', total: 9 })
+  })
+
+  it('retains the last value per exact token when retained', () => {
+    const bus = createHierarchicalPubSub<Events>({ retained: true })
+    bus.publish('order.created', { id: '1', total: 9 })
+
+    expect(bus.getSnapshot('order.created')).toEqual({ id: '1', total: 9 })
+    expect(bus.getSnapshot('order')).toBeUndefined() // exact-token only
+  })
+
+  it('routes a subscriber error to onError without crashing delivery', () => {
+    const onError = vi.fn()
+    const bus = createHierarchicalPubSub<Events>({ onError })
+    const after = vi.fn()
+    bus.subscribe('order.created', () => {
+      throw new Error('boom')
+    })
+    bus.subscribe('order', after)
+
+    bus.publish('order.created', { id: '1', total: 9 })
+    expect(() => flush()).not.toThrow()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(after).toBeCalledTimes(1)
+  })
+})

--- a/src/pubsub/hierarchical.spec.ts
+++ b/src/pubsub/hierarchical.spec.ts
@@ -83,4 +83,35 @@ describe('createHierarchicalPubSub', () => {
     expect(onError).toHaveBeenCalledTimes(1)
     expect(after).toBeCalledTimes(1)
   })
+
+  it('subscribeOnce fires once for a descendant publish, then auto-removes', () => {
+    const bus = createHierarchicalPubSub<Events>()
+    const handler = vi.fn()
+    bus.subscribeOnce('order', handler)
+
+    bus.publish('order.created', { id: '1', total: 9 })
+    flush()
+    bus.publish('order.created', { id: '2', total: 5 })
+    flush()
+
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('on() returns a cleanup that stops delivery, and supports AbortSignal', () => {
+    const bus = createHierarchicalPubSub<Events>()
+    const offHandler = vi.fn()
+    const signalHandler = vi.fn()
+    const off = bus.on('order', offHandler)
+    const controller = new AbortController()
+    bus.on('order', signalHandler, { signal: controller.signal })
+
+    off()
+    controller.abort()
+
+    bus.publish('order.created', { id: '1', total: 9 })
+    flush()
+
+    expect(offHandler).toBeCalledTimes(0)
+    expect(signalHandler).toBeCalledTimes(0)
+  })
 })

--- a/src/pubsub/hierarchical.test-d.ts
+++ b/src/pubsub/hierarchical.test-d.ts
@@ -1,0 +1,85 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { createHierarchicalPubSub, type DescendantKey } from './index'
+
+// biome-ignore lint/style/useConsistentTypeDefinitions: event maps must be type aliases (need the implicit index signature interfaces lack)
+type AppEvents = {
+  order: { id: string }
+  'order.created': { id: string; total: number }
+  'order.shipped': { id: string; carrier: string }
+  orders: { plural: true }
+  user: { name: string }
+}
+
+declare const sym: unique symbol
+// biome-ignore lint/style/useConsistentTypeDefinitions: event maps must be type aliases (need the implicit index signature interfaces lack)
+type SymEvents = {
+  [sym]: { v: number }
+  'a.b': { w: number }
+}
+
+describe('DescendantKey', () => {
+  it('includes the key itself and its dotted descendants', () => {
+    expectTypeOf<DescendantKey<AppEvents, 'order'>>().toEqualTypeOf<
+      'order' | 'order.created' | 'order.shipped'
+    >()
+  })
+
+  it('excludes a non-dotted prefix match (orders is not a descendant of order)', () => {
+    expectTypeOf<'orders'>().not.toMatchTypeOf<
+      DescendantKey<AppEvents, 'order'>
+    >()
+  })
+
+  it('resolves a leaf key to only itself', () => {
+    expectTypeOf<
+      DescendantKey<AppEvents, 'order.created'>
+    >().toEqualTypeOf<'order.created'>()
+  })
+
+  it('gives a symbol key no dotted descendants', () => {
+    expectTypeOf<DescendantKey<SymEvents, typeof sym>>().toEqualTypeOf<
+      typeof sym
+    >()
+  })
+})
+
+describe('createHierarchicalPubSub typing', () => {
+  const bus = createHierarchicalPubSub<AppEvents>()
+
+  it('types publish per exact key', () => {
+    expectTypeOf(bus.publish).toBeCallableWith('order.created', {
+      id: '1',
+      total: 1,
+    })
+    expectTypeOf(bus.getSnapshot('order.created')).toEqualTypeOf<
+      AppEvents['order.created'] | undefined
+    >()
+  })
+
+  it('gives the handler the descendant token union and payload union', () => {
+    bus.subscribe('order', (token, data) => {
+      expectTypeOf(token).toEqualTypeOf<
+        'order' | 'order.created' | 'order.shipped'
+      >()
+      expectTypeOf(data).toEqualTypeOf<
+        | AppEvents['order']
+        | AppEvents['order.created']
+        | AppEvents['order.shipped']
+      >()
+    })
+
+    bus.subscribe('order.shipped', (token, data) => {
+      expectTypeOf(token).toEqualTypeOf<'order.shipped'>()
+      expectTypeOf(data).toEqualTypeOf<AppEvents['order.shipped']>()
+    })
+  })
+
+  it('rejects wrong payloads and undeclared keys', () => {
+    // @ts-expect-error wrong payload shape
+    bus.publish('order.created', { id: '1' })
+    // @ts-expect-error undeclared key cannot be published
+    bus.publish('order.unknown', { id: '1' })
+    // @ts-expect-error undeclared key cannot be subscribed
+    bus.subscribe('order.unknown', () => undefined)
+  })
+})

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -315,3 +315,79 @@ export const createPubSub = <E extends EventMap = EventMap>(options?: {
 // annotation here is stripped by minification, so it would be a no-op.)
 /** The default shared bus: untyped payloads, hierarchical dotted topics. */
 export const PubSub: PubSubBus = createBus({ hierarchical: true })
+
+/**
+ * The keys of `E` that a hierarchical subscription to `K` will receive: `K`
+ * itself plus any dotted descendant (`a` matches `a.b`, `a.b.c`; not `ab`).
+ * Symbol keys match only themselves (no hierarchy).
+ */
+export type DescendantKey<E extends EventMap, K extends keyof E> = {
+  [P in keyof E]: P extends K
+    ? P
+    : K extends string
+      ? P extends `${K}.${string}`
+        ? P
+        : never
+      : never
+}[keyof E]
+
+/**
+ * A flat-keyed but **hierarchical** typed bus: publishing `'a.b.c'` also
+ * notifies subscribers of `'a.b'` and `'a'`, delivering the descendant's token
+ * and payload. Create with {@link createHierarchicalPubSub}.
+ *
+ * A handler's `token` is the precise union of descendant keys; `data` is the
+ * union of their payloads — narrow `data` with a property check (e.g.
+ * `'total' in data`), since TypeScript can't correlate the two parameters.
+ * Only declared keys can be published or subscribed.
+ */
+export interface HierarchicalPubSub<E extends EventMap> {
+  clearAllSubscriptions(): void
+  getSnapshot<K extends keyof E>(token: K): E[K] | undefined
+  on<K extends keyof E, D extends DescendantKey<E, K> = DescendantKey<E, K>>(
+    token: K,
+    handler: (token: D, data: E[D]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void
+  publish<K extends keyof E>(token: K, data: E[K]): boolean
+  subscribe<
+    K extends keyof E,
+    D extends DescendantKey<E, K> = DescendantKey<E, K>,
+  >(token: K, handler: (token: D, data: E[D]) => void): SubscriptionToken
+  subscribeOnce<
+    K extends keyof E,
+    D extends DescendantKey<E, K> = DescendantKey<E, K>,
+  >(token: K, handler: (token: D, data: E[D]) => void): SubscriptionToken
+  unsubscribe(
+    value: SubscriptionToken | ((...args: never[]) => unknown),
+  ): boolean
+}
+
+/**
+ * Create a typed bus with **hierarchical** dotted-topic delivery — the typed
+ * counterpart of the `PubSub` singleton. Same options as {@link createPubSub}.
+ *
+ * @example
+ * ```ts
+ * const bus = createHierarchicalPubSub<{
+ *   order: { id: string }
+ *   'order.created': { id: string; total: number }
+ * }>()
+ * bus.subscribe('order', (token, data) => {
+ *   // token: 'order' | 'order.created'; narrow data by a property check
+ *   if ('total' in data) console.log(data.total)
+ * })
+ * bus.publish('order.created', { id: '1', total: 9 }) // also notifies 'order'
+ * ```
+ */
+export const createHierarchicalPubSub = <
+  E extends EventMap = EventMap,
+>(options?: {
+  onError?: ErrorHandler
+  retained?: boolean
+}): HierarchicalPubSub<E> =>
+  createBus({
+    hierarchical: true,
+    retained: options?.retained,
+    onError: options?.onError,
+  }) as unknown as HierarchicalPubSub<E>

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/**/*.ts', '!src/**/*.spec.ts'],
+  entry: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.test-d.ts'],
   outDir: 'dist',
   format: ['esm', 'cjs'],
   dts: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     environment: 'jsdom',
     coverage: {
       include: ['src/**/*.ts'],
-      exclude: ['src/index.ts'],
+      // Barrel (re-exports only) and type-level tests (no runtime) are excluded.
+      exclude: ['src/index.ts', 'src/**/*.test-d.ts'],
       thresholds: {
         branches: 100,
         functions: 100,


### PR DESCRIPTION
Fills the last capability gap: `createPubSub` is flat-typed, the `PubSub` singleton is hierarchical-untyped — this is **both**. Publishing `order.created` also notifies `order`, with full payload typing. Additive/non-breaking.

- **`DescendantKey<E, K>`** (template-literal type): the keys a subscription to `K` receives — `K` + dotted descendants (`order` matches `order.created`, **not** `orders`); symbols match only themselves. Design adversarially reviewed with `tsc` proofs.
- **`HierarchicalPubSub<E>`** + **`createHierarchicalPubSub<E>(options?)`** (reuses the existing hierarchical runtime; `subscribe`/`on`/`subscribeOnce` use a defaulted `D` param so the descendant union is computed once).
- **Documented caveats:** a handler's `data` is narrowed by a property check, not by `token` (TS can't correlate the two params); only declared keys publish/subscribe.

**New CI infra:** `vitest --typecheck` type-level tests (`test:types` script + CI step, **no new deps**). `hierarchical.test-d.ts` pins DescendantKey edge cases + publish/subscribe/getSnapshot typing; runtime spec covers delivery, retained `getSnapshot`, and `onError`.

146 runtime tests + 7 type tests, 100% coverage, lint clean, e2e 12/12, attw 🌟 + publint clean, bundle within budget. README documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)