### PR TITLE
test(pubsub): cover on() cleanup with no signal (mutation-audit finding)

### DIFF
--- a/src/pubsub/pubsub.spec.ts
+++ b/src/pubsub/pubsub.spec.ts
@@ -321,6 +321,24 @@ describe('internal pub/sub module', () => {
       expect(handler).toBeCalledTimes(0)
     })
 
+    it('cleanup is safe when options are passed without a signal', () => {
+      const bus = createPubSub()
+      const off = bus.on('t', vi.fn(), {})
+
+      expect(() => off()).not.toThrow()
+    })
+
+    it('subscribes and cleans up safely when called without options', () => {
+      const bus = createPubSub()
+      const handler = vi.fn()
+      const off = bus.on('t', handler)
+
+      expect(() => off()).not.toThrow()
+      bus.publish('t', 'm')
+      flush()
+      expect(handler).toBeCalledTimes(0)
+    })
+
     it('removes the abort listener from the signal on manual unsubscribe', () => {
       const bus = createPubSub()
       const controller = new AbortController()


### PR DESCRIPTION
Ran a one-off **Stryker mutation audit** to find tests that pass without actually catching bugs — the systematic version of "find test gaps for safety."

**Score: 87% (224 mutants killed, 30 survived).** Triaged the survivors:
- **Equivalent mutants** (not worth contrived tests): empty-channel pruning (memory-only, unobservable) and React dependency-array mutations (the known near-unkillable class).
- **One real robustness gap:** `on(token, handler, {})` — options present but `signal` undefined. Cleanup did `options?.signal?.removeEventListener`; dropping the second `?.` throws, and no test exercised options-without-signal.

Added tests for `on()` with options-but-no-signal and `on()` with no options (cleanup must not throw). **Mutation-verified:** the new test fails if the `?.` is dropped.

Stryker was used as a **one-off audit, not added as a permanent dependency** (keeps the lib's devDeps lean); the 87% score + survivor analysis is recorded in memory for anyone who wants ongoing mutation testing later.

150 tests, 100% coverage, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)